### PR TITLE
Android Usage Guide : Instruction for when script not getting download. 

### DIFF
--- a/docs/Usage-Guide.md
+++ b/docs/Usage-Guide.md
@@ -36,6 +36,8 @@ This section provides a detailed guide on how to use JioTV Go for various platfo
 3. **Download Android Script:**
    - Download the Android script by running `curl -Lo jiotv_go.sh https://raw.githubusercontent.com/rabilrbl/jiotv_go/main/android.sh`.
 
+   *NOTE: If the above link does not work, try changing your internet connection or DNS settings. You may also consider using a VPN.*
+
 4. **Grant Executable Permissions:**
    - Grant executable permissions to the script with `chmod +x jiotv_go.sh`.
 


### PR DESCRIPTION
### Description

This pull request enhances the download instructions in the `docs/Usage-Guide.md` file to provide users with troubleshooting steps if the Android script download fails.

### Changes Made

Added a line to the download instructions suggesting users try changing their internet connection, DNS settings, or using a VPN if the provided link for the `.sh` file download does not work.


### Additional Notes

This enhancement aims to improve the user experience by providing guidance in case of download failures.
