### PR TITLE
Update image host to use https

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -453,7 +453,7 @@ func PlaylistHandler(c *fiber.Ctx) error {
 
 // ImageHandler loads image from JioTV server
 func ImageHandler(c *fiber.Ctx) error {
-	url := "http://jiotv.catchup.cdn.jio.com/dare_images/images/" + c.Params("file")
+	url := "https://jiotv.catchup.cdn.jio.com/dare_images/images/" + c.Params("file")
 	if err := proxy.Do(c, url, TV.Client); err != nil {
 		return err
 	}


### PR DESCRIPTION
Very minor update, resolves issues if your server is configured to block connections to non HTTPS hosts.