### PR TITLE
Refresh SSOToken while refreshing AuthToken

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -29,7 +29,8 @@ var (
 )
 
 const (
-	REFRESH_TOKEN_URL = "https://auth.media.jio.com/tokenservice/apis/v1/refreshtoken?langId=6"
+	REFRESH_TOKEN_URL     = "https://auth.media.jio.com/tokenservice/apis/v1/refreshtoken?langId=6"
+	REFRESH_SSO_TOKEN_URL = "https://tv.media.jio.com/apis/v2.0/loginotp/refresh?langId=6"
 )
 
 // Init initializes the necessary operations required for the handlers to work.
@@ -457,7 +458,7 @@ func FaviconHandler(c *fiber.Ctx) error {
 func PlaylistHandler(c *fiber.Ctx) error {
 	quality := c.Query("q")
 	isSplitCategory := c.Query("c")
-	return c.Redirect("/channels?type=m3u&q=" + quality + "&c=" + isSplitCategory, fiber.StatusMovedPermanently)
+	return c.Redirect("/channels?type=m3u&q="+quality+"&c="+isSplitCategory, fiber.StatusMovedPermanently)
 }
 
 // ImageHandler loads image from JioTV server

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -27,3 +27,9 @@ type RefreshTokenResponse struct {
 	// Access token for JioTV API
 	AccessToken string `json:"authToken"`
 }
+
+// RefreshTokenResponse represents Response body for refresh token request
+type RefreshSSOTokenResponse struct {
+	// Access token for JioTV API
+	SSOToken string `json:"ssoToken"`
+}

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -28,7 +28,7 @@ type RefreshTokenResponse struct {
 	AccessToken string `json:"authToken"`
 }
 
-// RefreshTokenResponse represents Response body for refresh token request
+// RefreshSSOTokenResponse represents Response body for refresh token request
 type RefreshSSOTokenResponse struct {
 	// Access token for JioTV API
 	SSOToken string `json:"ssoToken"`


### PR DESCRIPTION
Currently, we are only refreshing `AccessToken` whenever it is expired. 
This leads to a recurring issue where the user has to logout and re-login to make the channels work again. This issue should be solved if we also refresh `SSOToken` along with `AccessToken`