### PR TITLE
Arm64 fixed install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,7 +46,7 @@ case $ARCH in
     "x86_64")
         ARCH="amd64"
         ;;
-    "aarch64")
+    "aarch64" | "arm64")
         ARCH="arm64"
         ;;
     "i386" | "i686")


### PR DESCRIPTION
Identified architecture after uname -m detected system as arm when it was arm64. Fixed identification args to match the identified architecture.