### PR TITLE
Save categories while generating epg

### DIFF
--- a/pkg/epg/epg.go
+++ b/pkg/epg/epg.go
@@ -80,7 +80,7 @@ func Init() {
 }
 
 // NewProgramme creates a new Programme with the given parameters.
-func NewProgramme(channelID int, start, stop, title, desc, iconSrc string) Programme {
+func NewProgramme(channelID int, start, stop, title, desc, category, iconSrc string) Programme {
 	iconURL := fmt.Sprintf("/jtvposter/%s", iconSrc)
 	return Programme{
 		Channel: fmt.Sprint(channelID),
@@ -92,6 +92,10 @@ func NewProgramme(channelID int, start, stop, title, desc, iconSrc string) Progr
 		},
 		Desc: Desc{
 			Value: desc,
+			Lang:  "en",
+		},
+		Category: Category{
+			Value: category,
 			Lang:  "en",
 		},
 		Icon: Icon{
@@ -139,7 +143,7 @@ func genXML() ([]byte, error) {
 			for _, programme := range epgResponse.EPG {
 				startTime := formatTime(time.UnixMilli(programme.StartEpoch))
 				endTime := formatTime(time.UnixMilli(programme.EndEpoch))
-				programmes = append(programmes, NewProgramme(channel.ID, startTime, endTime, programme.Title, programme.Description, programme.Poster))
+				programmes = append(programmes, NewProgramme(channel.ID, startTime, endTime, programme.Title, programme.Description, programme.ShowCategory, programme.Poster))
 			}
 		}
 		bar.Add(1)

--- a/pkg/epg/types.go
+++ b/pkg/epg/types.go
@@ -27,6 +27,14 @@ type Title struct {
 	Lang    string   `xml:"lang,attr"` // Language of the title
 }
 
+// Category XML tag for Programme XML tag in EPG
+// Category is the type of the programme or show being aired on the channel
+type Category struct {
+	XMLName xml.Name `xml:"category"`
+	Value   string   `xml:",chardata"` // Category of the programme
+	Lang    string   `xml:"lang,attr"` // Language of the category
+}
+
 // Desc represents Description XML tag for Programme XML tag in EPG
 type Desc struct {
 	XMLName xml.Name `xml:"desc"`
@@ -37,13 +45,14 @@ type Desc struct {
 // Programme XML tag structure for EPG
 // Each programme tag represents a show being aired on a channel
 type Programme struct {
-	XMLName xml.Name `xml:"programme"`    // XML tag name
-	Channel string   `xml:"channel,attr"` // Channel is attribute of programme tag
-	Start   string   `xml:"start,attr"`   // Start time of the programme
-	Stop    string   `xml:"stop,attr"`    // Stop time of the programme
-	Title   Title    `xml:"title"`        // Title of the programme
-	Desc    Desc     `xml:"desc"`         // Description of the programme
-	Icon    Icon     `xml:"icon"`         // Icon of the programme
+	XMLName  xml.Name `xml:"programme"`    // XML tag name
+	Channel  string   `xml:"channel,attr"` // Channel is attribute of programme tag
+	Start    string   `xml:"start,attr"`   // Start time of the programme
+	Stop     string   `xml:"stop,attr"`    // Stop time of the programme
+	Title    Title    `xml:"title"`        // Title of the programme
+	Desc     Desc     `xml:"desc"`         // Description of the programme
+	Category Category `xml:"category"`     // Category of the programme
+	Icon     Icon     `xml:"icon"`         // Icon of the programme
 }
 
 // EPG XML tag structure


### PR DESCRIPTION
This change adds programme.showCategory as category so that media servers can use it to categorize the shows

ShowCategory of programmes from the api:
```
Business and Finance: 828
Business News: 72
News: 37039
Sports: 432
Sport: 1774
Education: 6192
Documentary: 1503
Infotainment: 864
Play: 27
TV Show: 31076
Radio Shows: 9
Music: 7193
Entertainment: 2096
Lifestyle: 600
Kids: 672
Children: 4007
Movies: 3610
Film: 2184
Devotional: 6119
```


How it works on jellyfin:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/5fca2b3d-02a9-4b47-8197-722eb3db3623">


ref: https://github.com/XMLTV/xmltv/blob/8c9d4a17e0253f758f8c863a70c1c5b0c70f3436/xmltv.dtd#L373-L378