### PR TITLE
Group channels by language only using c=language query parameter

### DIFF
--- a/docs/usage/iptv.md
+++ b/docs/usage/iptv.md
@@ -41,13 +41,31 @@ JioTV Go offers a convenient M3U playlist endpoint to enhance your IPTV experien
     ```
 	
 	This will filter only the specified languages (Tamil, English and Bengali).
+
+   The playlist will be split into categories like `Movies`, `Enterntainment`, `News`, `Music`, etc. but will only contain channels in the specified languages.
 	
 	Available Languages to filter `Hindi, Marathi, Punjabi, Urdu, Bengali, English, Malayalam, Tamil, Gujarati, Odia, Telugu, Bhojpuri, Kannada, Assamese, Nepali, French, Other`
+
+5. If you would like to group the M3U playlist by language only, append the `c=language` query parameter:
+
+    ```
+    http://localhost:5001/playlist.m3u?c=language
+    ```
+
+    This will group the playlist by language only, like `Hindi`, `Kannada`, `Marathi`, etc.
+
+   Please note that either `c=split` or `c=language` can be used at a time.
 
 For both specific quality and split category, append the `q=` and `c=` query parameters:
 
 ```
 http://localhost:5001/playlist.m3u?q=high&c=split
+```
+
+You can also combine the language grouping and language filtering:
+
+```
+http://localhost:5001/playlist.m3u?c=language&l=Hindi,Kannada,Marathi
 ```
 
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -358,7 +358,7 @@ func RenderTSHandler(c *fiber.Ctx) error {
 // Also to generate M3U playlist
 func ChannelsHandler(c *fiber.Ctx) error {
 	quality := strings.TrimSpace(c.Query("q"))
-	isSplitCategory := strings.TrimSpace(c.Query("c")) == "split"
+	splitCategory := strings.TrimSpace(c.Query("c"))
 	languages := strings.TrimSpace(c.Query("l"))
 	apiResponse := television.Channels()
 	// hostUrl should be request URL like http://localhost:5001
@@ -383,8 +383,10 @@ func ChannelsHandler(c *fiber.Ctx) error {
 			}
 			channelLogoURL := fmt.Sprintf("%s/%s", logoURL, channel.LogoURL)
 			var groupTitle string
-			if isSplitCategory {
+			if splitCategory == "split" {
 				groupTitle = fmt.Sprintf("%s - %s", television.CategoryMap[channel.Category], television.LanguageMap[channel.Language])
+			} else if splitCategory == "language" {
+				groupTitle = television.LanguageMap[channel.Language]
 			} else {
 				groupTitle = television.CategoryMap[channel.Category]
 			}
@@ -466,9 +468,9 @@ func FaviconHandler(c *fiber.Ctx) error {
 // For user convenience, redirect to /channels?type=m3u
 func PlaylistHandler(c *fiber.Ctx) error {
 	quality := c.Query("q")
-	isSplitCategory := c.Query("c")
+	splitCategory := c.Query("c")
 	languages := c.Query("l")
-	return c.Redirect("/channels?type=m3u&q="+quality+"&c="+isSplitCategory+"&l="+languages, fiber.StatusMovedPermanently)
+	return c.Redirect("/channels?type=m3u&q="+quality+"&c="+splitCategory+"&l="+languages, fiber.StatusMovedPermanently)
 }
 
 // ImageHandler loads image from JioTV server


### PR DESCRIPTION
# Group playlist channels based on language only
## Description
Currently the playlist channels can be grouped by below two options:
- By category (default)
  - Example: `Movies`, `Entertainment`, `News`, etc.
  - This is the default grouping
- By category - language
  - Example: `Movies - Hindi`, `Entertainment - Kannada`, `News - Telugu`, etc.
  - This grouping can be done by passing `c=split` request parameter to `/playlist.m3u` URL
### New addition
A new addition to the playlist channels grouping can be done via grouping by languages only. This will create groups based on language and will include all the channels from different categories of the language.
  - Example: `Hindi`, `Kannada`, `Telugu`, etc.
  - This grouping can be done by passing `c=language` request parameter to `/playlist.m3u` URL
  - This will still work in combination of `l` parameter to filter the languages i.e., `l=Hindi,Kannada,Telugu`