### PR TITLE
feat: Add query parameter to skip specific genres from m3u playlist

### DIFF
--- a/docs/usage/iptv.md
+++ b/docs/usage/iptv.md
@@ -56,6 +56,13 @@ JioTV Go offers a convenient M3U playlist endpoint to enhance your IPTV experien
 
    Please note that either `c=split` or `c=language` can be used at a time.
 
+6. If you would like to skip one or more genre from playlist, you can use  `sg=Educational,Lifestyle`
+   ```
+   http://localhost:5001/playlist.m3u?sg=Educational,Lifestyle
+   ```
+
+   This will skip all channels from provided list of genres.
+
 For both specific quality and split category, append the `q=` and `c=` query parameters:
 
 ```

--- a/docs/usage/paths.md
+++ b/docs/usage/paths.md
@@ -69,6 +69,9 @@ You can append `?q=<level>` to the path where `<level>` should be replaced with 
 
 You can also append `&c=split` to the path to have categories based on both language and genre. Example categories: `Hindi - Entertainment`, `English - News`, `Tamil - Sports`, etc.
 
+You can also append `&sg=<genre_list>` to the path in order to skip specific genres. Here replace `<genre_list>` with comma(,) seperated list of genres.
+Valid genres: `Entertainment`, `Movies`, `Kids`, `Sports`, `Lifestyle`, `Infotainment`, `News`, `Music`, `Devotional`, `Business`, `Educational`, `Shopping`, `JioDarshan`
+
 ### M3U Playlist
 
 - **Path**: `/channels?type=m3u`

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -376,6 +376,7 @@ func ChannelsHandler(c *fiber.Ctx) error {
 	quality := strings.TrimSpace(c.Query("q"))
 	splitCategory := strings.TrimSpace(c.Query("c"))
 	languages := strings.TrimSpace(c.Query("l"))
+	skipGenres := strings.TrimSpace(c.Query("sg"))
 	apiResponse := television.Channels()
 	// hostUrl should be request URL like http://localhost:5001
 	hostURL := strings.ToLower(c.Protocol()) + "://" + c.Hostname()
@@ -388,6 +389,10 @@ func ChannelsHandler(c *fiber.Ctx) error {
 		for _, channel := range apiResponse.Result {
 
 			if languages != "" && !utils.ContainsString(television.LanguageMap[channel.Language], strings.Split(languages, ",")) {
+				continue
+			}
+
+			if skipGenres != "" && utils.ContainsString(television.CategoryMap[channel.Category], strings.Split(skipGenres, ",")) {
 				continue
 			}
 
@@ -406,8 +411,8 @@ func ChannelsHandler(c *fiber.Ctx) error {
 			} else {
 				groupTitle = television.CategoryMap[channel.Category]
 			}
-			m3uContent += fmt.Sprintf("#EXTINF:-1 tvg-id=%s tvg-name=%q tvg-logo=%q tvg-language=%q tvg-type=%q group-title=%q, %s\n%s\n",
-				channel.ID, channel.Name, channelLogoURL, television.LanguageMap[channel.Language], television.CategoryMap[channel.Category], groupTitle, channel.Name, channelURL)
+			m3uContent += fmt.Sprintf("#EXTINF:-1 tvg-id=%s tvg-chno=%s tvg-name=%q tvg-logo=%q tvg-language=%q tvg-type=%q group-title=%q, %s\n%s\n",
+				channel.ID, channel.ID, channel.Name, channelLogoURL, television.LanguageMap[channel.Language], television.CategoryMap[channel.Category], groupTitle, channel.Name, channelURL)
 		}
 
 		// Set the Content-Disposition header for file download
@@ -485,7 +490,8 @@ func PlaylistHandler(c *fiber.Ctx) error {
 	quality := c.Query("q")
 	splitCategory := c.Query("c")
 	languages := c.Query("l")
-	return c.Redirect("/channels?type=m3u&q="+quality+"&c="+splitCategory+"&l="+languages, fiber.StatusMovedPermanently)
+	skipGenres := c.Query("sg")
+	return c.Redirect("/channels?type=m3u&q="+quality+"&c="+splitCategory+"&l="+languages+"&sg="+skipGenres, fiber.StatusMovedPermanently)
 }
 
 // ImageHandler loads image from JioTV server

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -411,8 +411,8 @@ func ChannelsHandler(c *fiber.Ctx) error {
 			} else {
 				groupTitle = television.CategoryMap[channel.Category]
 			}
-			m3uContent += fmt.Sprintf("#EXTINF:-1 tvg-id=%s tvg-chno=%s tvg-name=%q tvg-logo=%q tvg-language=%q tvg-type=%q group-title=%q, %s\n%s\n",
-				channel.ID, channel.ID, channel.Name, channelLogoURL, television.LanguageMap[channel.Language], television.CategoryMap[channel.Category], groupTitle, channel.Name, channelURL)
+			m3uContent += fmt.Sprintf("#EXTINF:-1 tvg-id=%s tvg-name=%q tvg-logo=%q tvg-language=%q tvg-type=%q group-title=%q, %s\n%s\n",
+				channel.ID, channel.Name, channelLogoURL, television.LanguageMap[channel.Language], television.CategoryMap[channel.Category], groupTitle, channel.Name, channelURL)
 		}
 
 		// Set the Content-Disposition header for file download


### PR DESCRIPTION
## Description:

This PR adds query parameter to skip some genres from playlist. This is useful for filtering playlist to skip channels from specific genres.
E.g.: `&sg=Devotional,Educational,Lifestyle,Shopping`

## Background:
I am using this server to add live tv channels to my Jellyfin. This is working flawlessly for last 2 weeks. Only issue I have is, there are too many channels that I dont need. This query param helps filter out some of the channels.
