### PR TITLE
Removed usage of GetPathPrefix function without reading the config

### DIFF
--- a/cmd/background.go
+++ b/cmd/background.go
@@ -12,7 +12,11 @@ import (
 )
 
 var PID_FILE_NAME = ".jiotv_go.pid"
-var PID_FILE_PATH = utils.GetPathPrefix() + PID_FILE_NAME
+var PID_FILE_PATH string
+
+func readPIDPath() {
+	PID_FILE_PATH = utils.GetPathPrefix() + PID_FILE_NAME
+}
 
 // RunInBackground starts the JioTV Go server as a background process by
 // executing the current binary with the provided arguments. It stores the
@@ -20,6 +24,7 @@ var PID_FILE_PATH = utils.GetPathPrefix() + PID_FILE_NAME
 // Returns any errors encountered while starting the process.
 func RunInBackground(args string) error {
 	fmt.Println("Starting JioTV Go server in background...")
+	readPIDPath()
 
 	// Get the path of the current binary executable
 	binaryExecutablePath, err := os.Executable()
@@ -52,12 +57,12 @@ func RunInBackground(args string) error {
 	return nil
 }
 
-
 // StopBackground stops the background JioTV Go server process that was previously
 // started with RunInBackground. It reads the PID from the PID file, sends a kill
 // signal to that process, and deletes the PID file. Returns any errors encountered.
 func StopBackground() error {
 	fmt.Println("Stopping JioTV Go server running in background...")
+	readPIDPath()
 
 	// Read the PID from the file
 	pidBytes, err := os.ReadFile(PID_FILE_PATH)

--- a/cmd/background.go
+++ b/cmd/background.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rabilrbl/jiotv_go/v3/internal/config"
 	"github.com/rabilrbl/jiotv_go/v3/pkg/utils"
 )
 
@@ -22,7 +23,11 @@ func readPIDPath() {
 // executing the current binary with the provided arguments. It stores the
 // process ID in a file in the user's home directory so it can be stopped later.
 // Returns any errors encountered while starting the process.
-func RunInBackground(args string) error {
+func RunInBackground(args string, configPath string) error {
+	if err := config.Cfg.Load(configPath); err != nil {
+		return err
+	}
+
 	fmt.Println("Starting JioTV Go server in background...")
 	readPIDPath()
 
@@ -34,6 +39,12 @@ func RunInBackground(args string) error {
 
 	cmdArgs := strings.Fields(args)
 	cmdArgs = append(cmdArgs, "--skip-update-check")
+
+	// Add current config path to args if not already explicitly provided
+	if !strings.Contains(args, "--config") {
+		cmdArgs = append(cmdArgs, "--config", configPath)
+	}
+
 	// Run JioTVServer function as a separate process
 	cmd := exec.Command(binaryExecutablePath, append([]string{"serve"}, cmdArgs...)...)
 	err = cmd.Start()
@@ -60,7 +71,11 @@ func RunInBackground(args string) error {
 // StopBackground stops the background JioTV Go server process that was previously
 // started with RunInBackground. It reads the PID from the PID file, sends a kill
 // signal to that process, and deletes the PID file. Returns any errors encountered.
-func StopBackground() error {
+func StopBackground(configPath string) error {
+	if err := config.Cfg.Load(configPath); err != nil {
+		return err
+	}
+
 	fmt.Println("Stopping JioTV Go server running in background...")
 	readPIDPath()
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -226,6 +226,8 @@ The `background` command allows you to run the JioTV Go server in the background
   jiotv_go background start [command options] [arguments...]
   ```
   - `--args value, -a value`: String value arguments passed to the `serve/run` command while running in the background as mentioned in the [Serve Command](#2-serve-command) section.
+  - `--config value, -c value`: Path to the configuration file. Reads the custom `path_prefix` to store the background process PID file at the specified location. Also passes the same configuration file to the `serve/run` command unless explicitly specified in `--args`.
+    <br>By default, JioTV Go will look for a file named `jiotv_go.(toml|yaml|json)` or `config.(toml|yaml|json)` in the same directory as the binary or `$HOME/.jiotv_go/` directory.
 
   Description: The `start` command starts the JioTV Go server in the background. It runs the `JioTVServer` function in a separate process.
 
@@ -233,6 +235,8 @@ The `background` command allows you to run the JioTV Go server in the background
   ```shell
   jiotv_go background stop
   ```
+  - `--config value, -c value`: Path to the configuration file. Reads the custom `path_prefix` to access the background process PID file at the location.
+    <br>By default, JioTV Go will look for a file named `jiotv_go.(toml|yaml|json)` or `config.(toml|yaml|json)` in the same directory as the binary or `$HOME/.jiotv_go/` directory.
 
   Description: The `stop` command stops the JioTV Go server running in the background. It will only work if the server is started using the `background start` command.
 
@@ -245,7 +249,7 @@ jiotv_go background start
 Example with arguments *(make sure to enclose the arguments in quotes)*:
 
 ```shell
-jiotv_go background start --args "--port 8080 --config config.toml"
+jiotv_go background start --config config.toml --args "--port 8080"
 ```
 
 ### Note:

--- a/main.go
+++ b/main.go
@@ -187,7 +187,8 @@ func main() {
 						Action: func(c *cli.Context) error {
 							cmd.PrintIfUpdateAvailable(c)
 							args := c.String("args")
-							return cmd.RunInBackground(args)
+							configPath := c.String("config")
+							return cmd.RunInBackground(args, configPath)
 						},
 						Flags: []cli.Flag{
 							&cli.StringFlag{
@@ -195,6 +196,12 @@ func main() {
 								Aliases: []string{"a"},
 								Value:   "",
 								Usage:   "String Value Arguments passed to serve/run command while running in the background",
+							},
+							&cli.StringFlag{
+								Name:    "config",
+								Aliases: []string{"c"},
+								Value:   "",
+								Usage:   "Path to config file",
 							},
 						},
 					},
@@ -204,7 +211,16 @@ func main() {
 						Usage:       "Stop JioTV Go server running in the background",
 						Description: "The stop command stops the JioTV Go server running in the background.",
 						Action: func(c *cli.Context) error {
-							return cmd.StopBackground()
+							configPath := c.String("config")
+							return cmd.StopBackground(configPath)
+						},
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:    "config",
+								Aliases: []string{"c"},
+								Value:   "",
+								Usage:   "Path to config file",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
- Added `--config` argument support to `background` commands
- Removed usage of `GetPathPrefix()` function before initializing the config file
- Fix #421