### PR TITLE
feat: add configurable favorite channels with M3U filtering

### DIFF
--- a/configs/jiotv-config.json
+++ b/configs/jiotv-config.json
@@ -12,5 +12,6 @@
     "log_to_stdout": false,
     "custom_channels_file": "",
     "default_categories": [],
-    "default_languages": []
+    "default_languages": [],
+    "favorite_channel_ids": []
 }

--- a/configs/jiotv-config.toml
+++ b/configs/jiotv-config.toml
@@ -42,3 +42,7 @@ default_categories = []
 # Default languages to display on the web page without filters. Array of language IDs. Default: []
 # Example: default_languages = [1, 6] # Hindi, English
 default_languages = []
+
+# Favorite Channel IDs to display in the M3U playlist when fav=true is used. Array of channel IDs. Default: []
+# Example: favorite_channel_ids = ["101", "102", "105"]
+favorite_channel_ids = []

--- a/configs/jiotv-config.yml
+++ b/configs/jiotv-config.yml
@@ -48,3 +48,8 @@ default_categories: []
 # Default languages to display on the web page without filters. Array of language IDs. Default: []
 # Example: [1, 6] # Hindi, English
 default_languages: []
+
+# Favorite Channel IDs to display in the M3U playlist when fav=true is used. Array of channel IDs. Default: []
+# Example: ["101", "102", "105"]
+favorite_channel_ids: []
+

--- a/docs/config.md
+++ b/docs/config.md
@@ -287,7 +287,7 @@ The file is also available at [configs/jiotv-config.json](https://github.com/jio
     "log_to_stdout": false,
     "custom_channels_file": "",
     "default_categories": [],
-    	"default_languages": [],
-    	"favorite_channel_ids": []
-    }
+    "default_languages": [],
+    "favorite_channel_ids": []
+}
     ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -155,6 +155,23 @@ JIOTV_DEFAULT_CATEGORIES=5,6 JIOTV_DEFAULT_LANGUAGES=1,6
 - Show only Entertainment and Movies channels in Hindi and English: `default_categories = [5, 6]`, `default_languages = [1, 6]`
 - Show all Sports channels regardless of language: `default_categories = [8]`, `default_languages = []`
 - Show all Hindi content regardless of category: `default_categories = []`, `default_languages = [1]`
+
+### Favorite Channel IDs:
+
+| Purpose | Config Value | Environment Variable | Default |
+| ----- | ------------ | -------------------- | ------- |
+| List of channel IDs to be marked as favorites. | `favorite_channel_ids` | `JIOTV_FAVORITE_CHANNEL_IDS` | `[]` (empty array) |
+
+This option allows you to specify a list of channel IDs that you want to mark as your favorites. These channels can then be filtered in the M3U playlist by using the `fav=true` query parameter in the `/channels?type=m3u` URL. The order of the channels in the list is preserved.
+
+**Environment Variable Format**: When using environment variables for array values, specify them as comma-separated values without spaces. For example:
+
+```bash
+JIOTV_FAVORITE_CHANNEL_IDS=101,102,105
+```
+
+**Example Use Cases**:
+- Create a playlist of your favorite channels: `favorite_channel_ids = ["101", "102", "105"]` and then access the playlist at `/channels?type=m3u&fav=true`.
 ## Example Configurations
 
 Below are example configuration file for JioTV Go. All fields are optional, and the values shown are the default settings:
@@ -217,6 +234,10 @@ default_categories = []
 # Default languages to display on the web interface when no filters are applied. Array of language IDs. Default: []
 # Example: default_languages = [1, 6] # Hindi, English
 default_languages = []
+
+# Favorite Channel IDs to display in the M3U playlist when fav=true is used. Array of channel IDs. Default: []
+# Example: favorite_channel_ids = ["101", "102", "105"]
+favorite_channel_ids = []
 ```
 
 This example demonstrates how to customize the configuration parameters using TOML syntax. Feel free to modify the values based on your preferences and requirements.
@@ -242,6 +263,7 @@ log_to_stdout: false
 custom_channels_file: ""
 default_categories: []
 default_languages: []
+favorite_channel_ids: []
 ```
 
 ### Example JSON Configuration
@@ -265,6 +287,7 @@ The file is also available at [configs/jiotv-config.json](https://github.com/jio
     "log_to_stdout": false,
     "custom_channels_file": "",
     "default_categories": [],
-    "default_languages": []
-}
-```
+    	"default_languages": [],
+    	"favorite_channel_ids": []
+    }
+    ```

--- a/docs/usage/paths.md
+++ b/docs/usage/paths.md
@@ -61,7 +61,9 @@ This section provides information about the API endpoints that JioTV Go offers. 
 
 You can append `?q=<level>` to the path where `<level>` should be replaced with `low`, `medium`, `high`, or `l`, `m`, `h` to set the quality of the stream. The default quality is `auto`.
 
-You can also append `&c=split` to the path to have categories based on both language and genre. Example categories: `Hindi - Entertainment`, `English - News`, `Tamil - Sports`, etc.
+You can also append `&fav=true` to the path to filter only your favorite channels. This requires you to have `favorite_channel_ids` configured in your config file. See [Config Documentation](../config.md#favorite-channel-ids) for more details.
+
+You can also append `&fav=true` to the path to filter only your favorite channels. This requires you to have `favorite_channel_ids` configured in your config file. See [Config Documentation](../config.md#favorite-channel-ids) for more details.
 
 You can also append `&sg=<genre_list>` to the path in order to skip specific genres. Here replace `<genre_list>` with comma(,) seperated list of genres.
 Valid genres: `Entertainment`, `Movies`, `Kids`, `Sports`, `Lifestyle`, `Infotainment`, `News`, `Music`, `Devotional`, `Business`, `Educational`, `Shopping`, `JioDarshan`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,8 @@ type JioTVConfig struct {
 	DefaultCategories []int `yaml:"default_categories" env:"JIOTV_DEFAULT_CATEGORIES" json:"default_categories" toml:"default_categories"`
 	// DefaultLanguages is the list of language IDs to display on the default web page. Default: []
 	DefaultLanguages []int `yaml:"default_languages" env:"JIOTV_DEFAULT_LANGUAGES" json:"default_languages" toml:"default_languages"`
+	// FavoriteChannelIDs is the list of channel IDs to be marked as favorites. Default: []
+	FavoriteChannelIDs []string `yaml:"favorite_channel_ids" env:"JIOTV_FAVORITE_CHANNEL_IDS" json:"favorite_channel_ids" toml:"favorite_channel_ids"`
 }
 
 // Cfg is the global config variable

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -516,7 +516,12 @@ func ChannelsHandler(c *fiber.Ctx) error {
 		// Create an M3U playlist
 		m3uContent := "#EXTM3U x-tvg-url=\"" + hostURL + "/epg.xml.gz\"\n"
 		logoURL := hostURL + "/jtvimage"
-		for _, channel := range apiResponse.Result {
+		channels := apiResponse.Result
+		if c.Query("fav") == "true" {
+			channels = television.FilterFavoriteChannels(channels)
+		}
+		utils.Log.Printf("FILTERED CHANNELS=%v\n", channels)
+		for _, channel := range channels {
 
 			if languages != "" && !utils.ContainsString(television.LanguageMap[channel.Language], strings.Split(languages, ",")) {
 				continue

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -520,7 +520,6 @@ func ChannelsHandler(c *fiber.Ctx) error {
 		if c.Query("fav") == "true" {
 			channels = television.FilterFavoriteChannels(channels)
 		}
-		utils.Log.Printf("FILTERED CHANNELS=%v\n", channels)
 		for _, channel := range channels {
 
 			if languages != "" && !utils.ContainsString(television.LanguageMap[channel.Language], strings.Split(languages, ",")) {

--- a/pkg/television/television.go
+++ b/pkg/television/television.go
@@ -528,6 +528,24 @@ func FilterChannelsByDefaults(channels []Channel, categories, languages []int) [
 	return filteredChannels
 }
 
+// FilterFavoriteChannels filters channels by favorite channel IDs and preserves the order.
+func FilterFavoriteChannels(channels []Channel) []Channel {
+	// Create a map of channels for efficient lookup
+	channelMap := make(map[string]Channel, len(channels))
+	for _, channel := range channels {
+		channelMap[channel.ID] = channel
+	}
+
+	// Create a slice of filtered channels, preserving the order from the config
+	filteredChannels := make([]Channel, 0, len(config.Cfg.FavoriteChannelIDs))
+	for _, id := range config.Cfg.FavoriteChannelIDs {
+		if channel, ok := channelMap[id]; ok {
+			filteredChannels = append(filteredChannels, channel)
+		}
+	}
+	return filteredChannels
+}
+
 func ReplaceM3U8(baseUrl, match []byte, params, channel_id string, quality string) []byte {
 	// Attempt to extract hdnea from params if present
 	hdnea := ""

--- a/web/static/internal/channels.js
+++ b/web/static/internal/channels.js
@@ -145,8 +145,9 @@ function displayFavoriteChannels() {
   });
 
   // Add all other cards to original fragment
+  const favoriteIdSet = new Set(favoriteIds);
   allChannelCards.forEach(card => {
-    if (!favoriteIds.includes(card.dataset.channelId)) {
+    if (!favoriteIdSet.has(card.dataset.channelId)) {
       originalFragment.appendChild(card);
     }
   });

--- a/web/static/internal/channels.js
+++ b/web/static/internal/channels.js
@@ -127,16 +127,26 @@ function displayFavoriteChannels() {
   }
 
   const allChannelCards = document.querySelectorAll('a.card[data-channel-id]');
+  const cardsMap = new Map();
+  allChannelCards.forEach(card => {
+    cardsMap.set(card.dataset.channelId, card);
+  });
 
   // Create DocumentFragments to batch DOM updates
   const favoriteFragment = document.createDocumentFragment();
   const originalFragment = document.createDocumentFragment();
 
-  allChannelCards.forEach(card => {
-    const cardChannelId = card.dataset.channelId;
-    if (favoriteIds.includes(cardChannelId)) {
+  // Add favorites to fragment in correct order
+  favoriteIds.forEach(id => {
+    const card = cardsMap.get(id);
+    if (card) {
       favoriteFragment.appendChild(card);
-    } else {
+    }
+  });
+
+  // Add all other cards to original fragment
+  allChannelCards.forEach(card => {
+    if (!favoriteIds.includes(card.dataset.channelId)) {
       originalFragment.appendChild(card);
     }
   });

--- a/web/views/channel_list.html
+++ b/web/views/channel_list.html
@@ -43,7 +43,7 @@
     </button>
   </div>
   <div id="favorite-channels-section" class="p-4" style="display: none;">
-    <h2 class="text-2xl font-bold mb-4">Favourites</h2>
+    <h2 class="text-2xl font-bold mb-4">Favorites</h2>
     <div id="favorite-channels-container" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 mt-4">
       <!-- Favorite channels will be moved here by JavaScript -->
     </div>
@@ -65,6 +65,7 @@
           class="h-14 w-14 sm:h-16 sm:w-16 md:h-18 md:w-18 lg:h-20 lg:w-20 rounded-full bg-gray-200"
         />
         <span class="text-lg font-bold mt-2">{{$channel.Name}}</span>
+        <span class="text-xs opacity-50">ID:{{$channel.ID}}</span>
         <button id="favorite-btn-{{$channel.ID}}" class="favorite-btn absolute btn-ghost p-0 sm:p-2 top-2 right-2 z-10 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200 rounded-full" aria-label="Add to favorites" onclick="event.preventDefault(); toggleFavorite('{{$channel.ID}}');">
           <svg  id="star-icon-{{$channel.ID}}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />


### PR DESCRIPTION
### API Enhancements

* **Configurable Favorite Channels:** A new `favorite_channel_ids` option has been added to all configuration files (`.json`, `.toml`, `.yml`) and can be set via the `JIOTV_FAVORITE_CHANNEL_IDS` environment variable. This allows users to specify an ordered list of favorite channel IDs.
* **M3U Playlist Filtering:** The `/channels?type=m3u` endpoint now accepts a `fav=true` query parameter. When this parameter is present, the generated M3U playlist will contain only the channels defined in the user's favorites list, preserving the specified order.


### UI Improvements

* **Ordered Display of Favorites:** The `displayFavoriteChannels` function has been updated to render favorite channels in the order they are defined by the user, rather than the default channel list order.
* **Channel ID Visibility:** The channel ID is now displayed on each channel card in the web UI, to find IDs faster, could make it a param/config variable for visibility. 
* **Typo Correction:** The spelling of "Favourites" has been corrected to "Favorites" in the user interface.


### Documentation Updates

* The `config.md` and `usage/paths.md` documents have been updated to include instructions for the new favorite channels feature and the `fav=true` query parameter.