### PR TITLE
fix: random stream freeze on token refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/madflojo/tasks v1.2.1
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
+	golang.org/x/sync v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -635,41 +635,58 @@ func RenderHandler(c *fiber.Ctx) error {
 		}
 
 		if channel_id != "" {
-			retryQuality := c.Query("q")
-			if retryQuality == "" {
-				retryQuality = "auto"
-			}
-
 			if refreshedLiveResult, refreshErr := TV.Live(channel_id); refreshErr == nil && refreshedLiveResult != nil {
 				if freshToken := extractLiveResultHDNEA(refreshedLiveResult); freshToken != "" {
 					setCachedHDNEA(channel_id, freshToken)
 					cachedHDNEA = freshToken
 				}
 
-				qualityCandidates := []string{retryQuality, "auto", "high", "medium", "low"}
-				triedURL := map[string]bool{renderURL: true}
+				if os.Getenv("JIOTV_DEBUG") == "true" {
+					utils.Log.Printf("[DEBUG] RenderHandler recovery - harvested fresh token, retrying original URL")
+				}
 
-				for _, candidateQuality := range qualityCandidates {
-					candidateURL := selectBestLiveHLSURL(refreshedLiveResult, candidateQuality)
-					candidateURL = toAbsoluteStreamURL(candidateURL, refreshedLiveResult)
-					if candidateURL == "" || triedURL[candidateURL] {
-						continue
+				// Retry the original decoded URL but stripped of any expired URL token,
+				// using the freshly harvested cachedHDNEA token we just acquired.
+				// This preserves the player's requested timeline sequence.
+				renderURL = stripHDNEAFromURL(decoded_url)
+				renderResult, statusCode, newHdnea = TV.Render(renderURL, cachedHDNEA)
+				if newHdnea != "" {
+					setCachedHDNEA(channel_id, newHdnea)
+					cachedHDNEA = newHdnea
+				}
+
+				// If the original URL STILL returns 404 (stale manifest that truly no longer exists),
+				// ONLY THEN do we fallback to the completely new base URL from TV.Live.
+				if statusCode == fiber.StatusNotFound {
+					retryQuality := c.Query("q")
+					if retryQuality == "" {
+						retryQuality = "auto"
 					}
-					triedURL[candidateURL] = true
+					qualityCandidates := []string{retryQuality, "auto", "high", "medium", "low"}
+					triedURL := map[string]bool{renderURL: true}
 
-					if os.Getenv("JIOTV_DEBUG") == "true" {
-						utils.Log.Printf("[DEBUG] RenderHandler recovery - trying quality=%s for channel=%s", candidateQuality, channel_id)
-					}
+					for _, candidateQuality := range qualityCandidates {
+						candidateURL := selectBestLiveHLSURL(refreshedLiveResult, candidateQuality)
+						candidateURL = toAbsoluteStreamURL(candidateURL, refreshedLiveResult)
+						if candidateURL == "" || triedURL[candidateURL] {
+							continue
+						}
+						triedURL[candidateURL] = true
 
-					renderURL = candidateURL
-					renderResult, statusCode, newHdnea = TV.Render(renderURL, cachedHDNEA)
-					if newHdnea != "" {
-						setCachedHDNEA(channel_id, newHdnea)
-						cachedHDNEA = newHdnea
-					}
+						if os.Getenv("JIOTV_DEBUG") == "true" {
+							utils.Log.Printf("[DEBUG] RenderHandler 404 recovery - trying new candidate URL for quality=%s", candidateQuality)
+						}
 
-					if statusCode == fiber.StatusOK {
-						break
+						renderURL = candidateURL
+						renderResult, statusCode, newHdnea = TV.Render(renderURL, cachedHDNEA)
+						if newHdnea != "" {
+							setCachedHDNEA(channel_id, newHdnea)
+							cachedHDNEA = newHdnea
+						}
+
+						if statusCode == fiber.StatusOK {
+							break
+						}
 					}
 				}
 			}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/proxy"
+	"golang.org/x/sync/singleflight"
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 	EnableDRM        bool
 	SONY_LIST        = []string{"154", "155", "162", "289", "291", "471", "474", "476", "483", "514", "524", "525", "697", "872", "873", "874", "891", "892", "1146", "1393", "1772", "1773", "1774", "1775"}
 	renderHDNEACache sync.Map
+	tokenRefreshGroup singleflight.Group
 )
 
 const (
@@ -361,13 +363,37 @@ func liveResultNeedsRefresh(liveResult *television.LiveURLOutput) bool {
 	return ok && remaining <= hdneaRefreshLeadTime
 }
 
+// refreshChannelToken safely fetches a fresh stream using singleflight to prevent multiple
+// concurrent API requests for the same channel ID when a token expires (thundering herd).
+func refreshChannelToken(channelID string) (*television.LiveURLOutput, error) {
+	if channelID == "" {
+		return nil, fmt.Errorf("empty channel ID")
+	}
+
+	// Use singleflight to ensure only one concurrent TV.Live request per channelID
+	v, err, _ := tokenRefreshGroup.Do(channelID, func() (interface{}, error) {
+		return TV.Live(channelID)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	result, ok := v.(*television.LiveURLOutput)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type from singleflight")
+	}
+
+	return result, nil
+}
+
 func refreshLiveResultIfNeeded(channelID string, liveResult *television.LiveURLOutput) (*television.LiveURLOutput, error) {
 	if channelID == "" || liveResult == nil || !liveResultNeedsRefresh(liveResult) {
 		return liveResult, nil
 	}
 
 	utils.Log.Printf("HDNEA token is near expiry for channel %s; refreshing live URL", channelID)
-	refreshedResult, err := TV.Live(channelID)
+	refreshedResult, err := refreshChannelToken(channelID)
 	if err != nil {
 		return liveResult, err
 	}
@@ -635,7 +661,7 @@ func RenderHandler(c *fiber.Ctx) error {
 		}
 
 		if channel_id != "" {
-			if refreshedLiveResult, refreshErr := TV.Live(channel_id); refreshErr == nil && refreshedLiveResult != nil {
+			if refreshedLiveResult, refreshErr := refreshChannelToken(channel_id); refreshErr == nil && refreshedLiveResult != nil {
 				if freshToken := extractLiveResultHDNEA(refreshedLiveResult); freshToken != "" {
 					setCachedHDNEA(channel_id, freshToken)
 					cachedHDNEA = freshToken
@@ -894,7 +920,7 @@ func RenderTSHandler(c *fiber.Ctx) error {
 
 		retryUrl := stripHDNEAFromURL(decoded_url)
 		if channelID != "" {
-			if refreshedResult, refreshErr := TV.Live(channelID); refreshErr == nil && refreshedResult != nil {
+			if refreshedResult, refreshErr := refreshChannelToken(channelID); refreshErr == nil && refreshedResult != nil {
 				if refreshedHDNEA := extractLiveResultHDNEA(refreshedResult); refreshedHDNEA != "" {
 					setCachedHDNEA(channelID, refreshedHDNEA)
 					c.Request().Header.SetCookie("__hdnea__", refreshedHDNEA)

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -819,6 +819,9 @@ func SLHandler(c *fiber.Ctx) error {
 // RenderKeyHandler requests m3u8 key from JioTV server
 func RenderKeyHandler(c *fiber.Ctx) error {
 	channel_id := c.Query("channel_key_id")
+	if err := internalUtils.ValidateRequiredParam("channel_key_id", channel_id); err != nil {
+		return err
+	}
 	auth := c.Query("auth")
 	// parse incoming hdnea query and set as request cookie only for upstream call (no client cookie)
 	if hdnea := c.Query("hdnea"); hdnea != "" {
@@ -868,6 +871,9 @@ func RenderTSHandler(c *fiber.Ctx) error {
 	}
 
 	channelID := c.Query("channel_key_id")
+	if err := internalUtils.ValidateRequiredParam("channel_key_id", channelID); err != nil {
+		return err
+	}
 	auth := c.Query("auth")
 	// parse incoming hdnea query and set as request cookie only for upstream call (no client cookie)
 	if hdnea := c.Query("hdnea"); hdnea != "" {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -625,52 +625,18 @@ func RenderHandler(c *fiber.Ctx) error {
 		cachedHDNEA = newHdnea
 	}
 
-	// On authentication failure, retry without any cached token
-	if statusCode == fiber.StatusForbidden || statusCode == fiber.StatusUnauthorized {
-		// Clear the stale cached token and force fresh token extraction
-		renderHDNEACache.Delete(channel_id)
+	// On authentication failure or 404, unify the retry logic by fetching a fresh stream URL
+	if statusCode == fiber.StatusForbidden || statusCode == fiber.StatusUnauthorized || statusCode == fiber.StatusNotFound {
+		// Clear the stale cached token
+		if statusCode != fiber.StatusNotFound {
+			renderHDNEACache.Delete(channel_id)
+		}
 
 		if os.Getenv("JIOTV_DEBUG") == "true" {
-			utils.Log.Printf("[DEBUG] Auth failure (Status %d) - clearing cache and retrying with fresh auth", statusCode)
+			utils.Log.Printf("[DEBUG] Auth failure or not found (Status %d) - fetching fresh live URL and auth", statusCode)
 		}
 
-		// Always retry on 403/401, regardless of whether HDNEA is in URL
-		// Some URLs have HDNEA embedded, others don't - but CDN always needs fresh tokens
-		strippedURL := stripHDNEAFromURL(decoded_url)
-		if strippedURL != renderURL {
-			renderURL = strippedURL
-			if os.Getenv("JIOTV_DEBUG") == "true" {
-				utils.Log.Printf("[DEBUG] Stripped HDNEA from URL for retry")
-			}
-		}
-
-		// Retry without any cached HDNEA token - let CDN provide fresh auth
-		renderResult, statusCode, newHdnea = TV.Render(renderURL, "")
-		if newHdnea != "" {
-			setCachedHDNEA(channel_id, newHdnea)
-			cachedHDNEA = newHdnea
-			if os.Getenv("JIOTV_DEBUG") == "true" {
-				utils.Log.Printf("[DEBUG] Retry successful - extracted fresh token: %s", truncateToken(newHdnea))
-			}
-		} else if os.Getenv("JIOTV_DEBUG") == "true" {
-			utils.Log.Printf("[DEBUG] Retry completed - new status: %d", statusCode)
-		}
-	} else if statusCode == fiber.StatusNotFound {
-		wasNotFound := true
-		strippedURL := stripHDNEAFromURL(decoded_url)
-		if strippedURL != renderURL {
-			renderURL = strippedURL
-			renderResult, statusCode, newHdnea = TV.Render(renderURL, cachedHDNEA)
-			if newHdnea != "" {
-				setCachedHDNEA(channel_id, newHdnea)
-				cachedHDNEA = newHdnea
-			}
-		}
-
-		// Some channels occasionally return stale HLS manifests (404).
-		// Do a bounded retry with a freshly fetched live URL.
-		// If the requested quality variant is broken, try alternative qualities once.
-		if wasNotFound && channel_id != "" {
+		if channel_id != "" {
 			retryQuality := c.Query("q")
 			if retryQuality == "" {
 				retryQuality = "auto"
@@ -694,7 +660,7 @@ func RenderHandler(c *fiber.Ctx) error {
 					triedURL[candidateURL] = true
 
 					if os.Getenv("JIOTV_DEBUG") == "true" {
-						utils.Log.Printf("[DEBUG] RenderHandler 404 recovery - trying quality=%s for channel=%s", candidateQuality, channel_id)
+						utils.Log.Printf("[DEBUG] RenderHandler recovery - trying quality=%s for channel=%s", candidateQuality, channel_id)
 					}
 
 					renderURL = candidateURL
@@ -873,9 +839,15 @@ func RenderTSHandler(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Check if decoded_url has hdnea or __hdnea__ and set cookie if not already set
-	// This is crucial when hdnea is embedded in the encrypted auth URL but not in the request query params
-	if len(c.Request().Header.Cookie("__hdnea__")) == 0 && strings.Contains(decoded_url, "hdnea=") {
+	// Always prefer a freshly cached HDNEA token if available
+	cachedHDNEA := getCachedHDNEA(channelID)
+	if cachedHDNEA != "" {
+		c.Request().Header.SetCookie("__hdnea__", cachedHDNEA)
+		// We should also replace the token in the URL if it's there
+		decoded_url = stripHDNEAFromURL(decoded_url)
+	} else if len(c.Request().Header.Cookie("__hdnea__")) == 0 && strings.Contains(decoded_url, "hdnea=") {
+		// Check if decoded_url has hdnea or __hdnea__ and set cookie if not already set
+		// This is crucial when hdnea is embedded in the encrypted auth URL but not in the request query params
 		qIdx := strings.Index(decoded_url, "?")
 		if qIdx != -1 {
 			params := decoded_url[qIdx+1:]
@@ -904,9 +876,6 @@ func RenderTSHandler(c *fiber.Ctx) error {
 
 		c.Response().Reset()
 		c.Request().Header.DelCookie("__hdnea__")
-		if !ForceRefreshCredentials() && os.Getenv("JIOTV_DEBUG") == "true" {
-			utils.Log.Printf("[DEBUG] RenderTSHandler forced refresh did not update credentials")
-		}
 
 		retryUrl := stripHDNEAFromURL(decoded_url)
 		if channelID != "" {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -587,31 +587,29 @@ func RenderHandler(c *fiber.Ctx) error {
 
 	decoded_url = toAbsoluteStreamURL(decoded_url, nil)
 
-	// Extract fresh token from URL if present (primary source, always fresh)
+	// Always prefer a freshly cached HDNEA token if available to prevent 403s on expired URL tokens
+	cachedHDNEA := getCachedHDNEA(channel_id)
 	urlToken := extractHDNEAFromURL(decoded_url)
-	var cachedHDNEA string
 
-	// AGGRESSIVE REFRESH: Always prefer fresh URL token over cache to prevent 403 errors from stale tokens
-	if urlToken != "" {
+	renderURL := decoded_url
+	if cachedHDNEA != "" {
+		// We have a freshly fetched token from a recent recovery, use it instead of the potentially expired URL token
+		renderURL = stripHDNEAFromURL(decoded_url)
+	} else if urlToken != "" {
 		cachedHDNEA = urlToken
-	} else {
-		cachedHDNEA = getCachedHDNEA(channel_id)
 	}
 
 	// DEBUG: Log token selection
 	if os.Getenv("JIOTV_DEBUG") == "true" {
-		sourceStr := "URL"
-		if urlToken == "" && cachedHDNEA != "" {
-			sourceStr = "cache"
-		}
-		if urlToken == "" && cachedHDNEA == "" {
+		sourceStr := "cache"
+		if cachedHDNEA == "" {
 			sourceStr = "none"
+		} else if cachedHDNEA == urlToken {
+			sourceStr = "URL"
 		}
 		utils.Log.Printf("[DEBUG] Token selection - URL token: %s | Cached token: %s | Using: %s (source: %s)",
 			truncateToken(urlToken), truncateToken(getCachedHDNEA(channel_id)), truncateToken(cachedHDNEA), sourceStr)
 	}
-
-	renderURL := decoded_url
 	renderResult, statusCode, newHdnea := TV.Render(renderURL, cachedHDNEA)
 
 	// DEBUG: Log token extraction and response


### PR DESCRIPTION
This fix is generated by Google Labs Jules running Gemini 3.1 Pro, and has been tested to be stable for over 20 minutes.

The Problem:
```
jiotv_go | [DEBUG] 2026/05/04 07:16:45 handlers.go:610: [DEBUG] Token selection - URL token: st=1777878...ae89353a1f | Cached token: (empty) | Using: st=1777878...ae89353a1f (source: URL)
jiotv_go | [DEBUG] 2026/05/04 07:16:46 handlers.go:619: [DEBUG] Render response - Status: 403 | Token from response: (empty)
jiotv_go | [DEBUG] 2026/05/04 07:16:46 handlers.go:634: [DEBUG] Auth failure (Status 403) - clearing cache and retrying with fresh auth
jiotv_go | [DEBUG] 2026/05/04 07:16:46 handlers.go:643: [DEBUG] Stripped HDNEA from URL for retry
jiotv_go | [DEBUG] 2026/05/04 07:16:46 handlers.go:656: [DEBUG] Retry completed - new status: 403
jiotv_go | [DEBUG] 2026/05/04 07:16:46 handlers.go:787: Error rendering M3U8 file
jiotv_go | [07:16:45] 403 - 237.591866ms GET /render.m3u8 Params:[auth=[REDACTED]&channel_key_id=464&q=high]

jiotv_go | [DEBUG] 2026/05/04 07:16:51 handlers.go:610: [DEBUG] Token selection - URL token: st=1777878...ae89353a1f | Cached token: (empty) | Using: st=1777878...ae89353a1f (source: URL)
jiotv_go | [DEBUG] 2026/05/04 07:16:51 handlers.go:619: [DEBUG] Render response - Status: 403 | Token from response: (empty)
jiotv_go | [DEBUG] 2026/05/04 07:16:51 handlers.go:634: [DEBUG] Auth failure (Status 403) - clearing cache and retrying with fresh auth
jiotv_go | [DEBUG] 2026/05/04 07:16:51 handlers.go:643: [DEBUG] Stripped HDNEA from URL for retry
jiotv_go | [DEBUG] 2026/05/04 07:16:51 handlers.go:656: [DEBUG] Retry completed - new status: 403
jiotv_go | [DEBUG] 2026/05/04 07:16:51 handlers.go:787: Error rendering M3U8 file
jiotv_go | [07:16:51] 403 - 12.968941ms GET /render.m3u8 Params:[auth=[REDACTED]&channel_key_id=464&q=high]

jiotv_go | [07:17:06] 302 - 125.036057ms GET /live/high/464.m3u8 Params:[]
jiotv_go | [DEBUG] 2026/05/04 07:17:06 handlers.go:610: [DEBUG] Token selection - URL token: st=1777879...b6b2062c05 | Cached token: (empty) | Using: st=1777879...b6b2062c05 (source: URL)
jiotv_go | [DEBUG] 2026/05/04 07:17:06 handlers.go:619: [DEBUG] Render response - Status: 200 | Token from response: (empty)
jiotv_go | [07:17:06] 200 - 111.882164ms GET /render.m3u8 Params:[auth=[REDACTED]&channel_key_id=464&q=high]

jiotv_go | [DEBUG] 2026/05/04 07:17:06 handlers.go:610: [DEBUG] Token selection - URL token: st=1777879...b6b2062c05 | Cached token: (empty) | Using: st=1777879...b6b2062c05 (source: URL)
jiotv_go | [DEBUG] 2026/05/04 07:17:06 handlers.go:619: [DEBUG] Render response - Status: 200 | Token from response: (empty)
jiotv_go | [07:17:06] 200 - 60.309501ms GET /render.m3u8 Params:[auth=[REDACTED]&channel_key_id=464&q=high]

jiotv_go | [DEBUG] 2026/05/04 07:17:06 handlers.go:610: [DEBUG] Token selection - URL token: st=1777879...b6b2062c05 | Cached token: (empty) | Using: st=1777879...b6b2062c05 (source: URL)
jiotv_go | [DEBUG] 2026/05/04 07:17:06 handlers.go:619: [DEBUG] Render response - Status: 200 | Token from response: (empty)
```

After the token expires/gets deauthenticated, the stream abruptly stops because the URL and token is not updated, causing a client crash or freeze on apps like Kodi or m3uandroid. 

What this PR does:
**Aggressive Token Caching**: The server now actively caches the freshest HDNEA token in memory (renderHDNEACache).

**Prioritizing Cached Tokens**: In RenderHandler (for .m3u8 playlists) and RenderTSHandler (for .ts chunks), the server intercepts incoming requests. If a freshly cached token exists, the server prefers it over the (potentially expired) token provided in the client's URL. The server automatically strips the expired token from the URL and injects the fresh cached token into the upstream proxy request.

**Preserving the HLS Timeline**: When a 403/401 error does occur (meaning the cache expired), the server makes a single call to TV.Live() to harvest a fresh token. Crucially, instead of serving the completely new stream URL returned by the API (which breaks the media sequence), it takes the fresh token and applies it to the original timeline URL requested by the client player.

**Preventing API Spam**: By relying on the channel-specific cached token, we avoid redundant TV.Live() calls. Additionally, the global ForceRefreshCredentials() call was removed from RenderTSHandler on 403s to prevent concurrent .ts requests from spamming the global JioTV login API during token rotations.

Tested on:
m3uandroid 1.15.0 on Android 16
Kodi 21.3 on Android TV 9

Fresh PR created due to GitHub lagging