### PR TITLE
feat: implement Android x86 (32-bit) build support

### DIFF
--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -38,6 +38,10 @@ for var in $(go tool dist list); do
                     cc="x86_64-linux-android32-clang"
                     cxx="x86_64-linux-android32-clang++"
                     ;;
+                "386")
+                    cc="i686-linux-android32-clang"
+                    cxx="i686-linux-android32-clang++"
+                    ;;    
                 *)
                     echo "Skipping: $var"
                     continue


### PR DESCRIPTION
Adds support for building Android binaries targeting the 386 (x86 32-bit) architecture.

Closes #766