### PR TITLE
fix: restore EPG programme generation

### DIFF
--- a/internal/constants/urls/urls.go
+++ b/internal/constants/urls/urls.go
@@ -27,7 +27,7 @@ const (
 	ChannelURL     = "https://jiotv.data.cdn.jio.com/apis/v3.0/getMobileChannelList/get/?os=android&devicetype=phone&usertype=tvYR7NSNn7rymo3F"
 
 	// EPG URLs
-	EPGURL            = "https://jiotv.data.cdn.jio.com/apis/v1.3/getepg/get/?offset=%d&channel_id=%d"
+	EPGURL            = "https://jiotv.data.cdn.jio.com/apis/v1.3/getepg/get?offset=%d&channel_id=%d"
 	EPGPosterURL      = "https://jiotv.catchup.cdn.jio.com/dare_images/shows"
 	EPGPosterURLSlash = "https://jiotv.catchup.cdn.jio.com/dare_images/shows/"
 )

--- a/internal/constants/urls/urls_test.go
+++ b/internal/constants/urls/urls_test.go
@@ -1,0 +1,15 @@
+package urls
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestEPGURL(t *testing.T) {
+	got := fmt.Sprintf(EPGURL, 1, 143)
+	want := "https://jiotv.data.cdn.jio.com/apis/v1.3/getepg/get?offset=1&channel_id=143"
+
+	if got != want {
+		t.Fatalf("EPGURL formatted as %q, want %q", got, want)
+	}
+}

--- a/pkg/epg/epg.go
+++ b/pkg/epg/epg.go
@@ -41,7 +41,7 @@ func Init() {
 	var lastModTime time.Time
 	flag := false
 	utils.Log.Println("Checking EPG file")
-	
+
 	// Check file existence and get file info
 	fileResult := utils.CheckAndReadFile(epgFile)
 	if fileResult.Exists {
@@ -131,9 +131,11 @@ func genXML() ([]byte, error) {
 	// Create channels and programmes slices with initial capacity
 	var channels []Channel
 	var programmes []Programme
+	var programmesMu sync.Mutex
 
 	// Define a worker function for fetching EPG data
 	fetchEPG := func(channel Channel, bar *progressbar.ProgressBar) {
+		var channelProgrammes []Programme
 		req := fasthttp.AcquireRequest()
 		req.Header.SetUserAgent(headers.UserAgentOkHttp)
 		defer fasthttp.ReleaseRequest(req)
@@ -149,6 +151,10 @@ func genXML() ([]byte, error) {
 				utils.Log.Printf("Error fetching EPG for channel %d, offset %d: %v", channel.ID, offset, err)
 				continue
 			}
+			if status := resp.StatusCode(); status != fasthttp.StatusOK {
+				utils.Log.Printf("Error fetching EPG for channel %d, offset %d: HTTP status %d", channel.ID, offset, status)
+				continue
+			}
 
 			var epgResponse EPGResponse
 			if err := json.Unmarshal(resp.Body(), &epgResponse); err != nil {
@@ -162,9 +168,12 @@ func genXML() ([]byte, error) {
 			for _, programme := range epgResponse.EPG {
 				startTime := formatTime(time.UnixMilli(programme.StartEpoch))
 				endTime := formatTime(time.UnixMilli(programme.EndEpoch))
-				programmes = append(programmes, NewProgramme(channel.ID, startTime, endTime, programme.Title, programme.Description, programme.ShowCategory, programme.Poster))
+				channelProgrammes = append(channelProgrammes, NewProgramme(channel.ID, startTime, endTime, programme.Title, programme.Description, programme.ShowCategory, programme.Poster))
 			}
 		}
+		programmesMu.Lock()
+		programmes = append(programmes, channelProgrammes...)
+		programmesMu.Unlock()
 		bar.Add(1)
 		fasthttp.ReleaseResponse(resp)
 	}
@@ -217,6 +226,9 @@ func genXML() ([]byte, error) {
 	}
 	close(channelQueue)
 	wg.Wait()
+	if len(programmes) == 0 {
+		return nil, fmt.Errorf("no EPG programmes were fetched")
+	}
 
 	utils.Log.Println("Fetched programmes")
 	// Create EPG and marshal it to XML


### PR DESCRIPTION
## Summary

- remove the trailing slash from the Jio EPG route so requests return programme data again
- reject non-200 responses and avoid publishing a channel-only guide when every EPG request fails
- aggregate per-channel programmes safely across the worker pool
- add regression coverage for the formatted EPG URL

## Root cause

The current `/get/?offset=...` route returns HTTP 404, while `/get?offset=...` returns the expected JSON. Because response status and the final programme count were not checked, generation still succeeded with zero `<programme>` entries.

## Validation

- `go test ./...`
- built and ran the patched Docker image against the live API
- generated 78,113 programmes across all 1,181 channels with a two-day guide range

Fixes #759
Related to #774
