### PR TITLE
fix: strip browser headers before proxying render.key upstream

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -855,7 +855,11 @@ func RenderKeyHandler(c *fiber.Ctx) error {
 	c.Request().Header.Set("srno", "230203144000")
 	c.Request().Header.Set("ssotoken", TV.SsoToken)
 	c.Request().Header.Set("channelId", channel_id)
-	c.Request().Header.Set("User-Agent", PLAYER_USER_AGENT)
+	// Strip browser-added headers before proxying upstream. The key endpoint
+	// rejects requests carrying an Origin header with 403, which breaks
+	// AES-128 channels for any browser-based player served from a different
+	// origin (for example Jellyfin on :8096 requesting keys from :5001).
+	internalUtils.SetPlayerHeaders(c, PLAYER_USER_AGENT)
 	if err := proxy.Do(c, decoded_url, TV.Client); err != nil {
 		return err
 	}

--- a/internal/utils/handlers_test.go
+++ b/internal/utils/handlers_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
@@ -78,4 +79,34 @@ func TestDecryptURLParam(t *testing.T) {
 	// Test invalid encrypted URL
 	_, err = DecryptURLParam("test", "invalid")
 	assert.Error(t, err, "Expected error for invalid encrypted URL")
+}
+func TestSetPlayerHeadersStripsBrowserHeaders(t *testing.T) {
+	// A browser playing from a different origin adds Origin and Referer. The
+	// JioTV key endpoint answers 403 to any request carrying Origin, so these
+	// must not be forwarded upstream.
+	app := fiber.New()
+	app.Get("/test", func(c *fiber.Ctx) error {
+		c.Request().Header.Set("Origin", "http://localhost:8096")
+		c.Request().Header.Set("Referer", "http://localhost:8096/")
+		c.Request().Header.Set("Accept", "*/*")
+		c.Request().Header.Set("Accept-Encoding", "gzip")
+		c.Request().Header.Set("Accept-Language", "en-GB")
+
+		SetPlayerHeaders(c, "TestPlayer/1.0")
+
+		assert.Empty(t, string(c.Request().Header.Peek("Origin")),
+			"Origin must be stripped before proxying upstream")
+		assert.Empty(t, string(c.Request().Header.Peek("Referer")),
+			"Referer must be stripped before proxying upstream")
+		assert.Empty(t, string(c.Request().Header.Peek("Accept")))
+		assert.Empty(t, string(c.Request().Header.Peek("Accept-Encoding")))
+		assert.Empty(t, string(c.Request().Header.Peek("Accept-Language")))
+		assert.Equal(t, "TestPlayer/1.0", string(c.Request().Header.Peek("User-Agent")))
+		return nil
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
## Problem

`RenderKeyHandler` forwards the incoming request's `Origin` header to the JioTV key endpoint, which answers **403** to any request carrying it.

Browsers add `Origin` automatically on cross-origin requests, so every **AES-128 encrypted channel** fails to play in any browser-based player served from a different origin. In my case Jellyfin's web player runs on `:8096` and requests keys from `jiotv_go` on `:5001`; the channel sits on the loading spinner while hls.js retries `render.key` and gets 403 each time.

This affected **36 of the 50** JioTV channels in my playlist. Native apps are unaffected, because only browsers send `Origin`.

## Reproduction

Same key URL, issued once, requested repeatedly — only the header differs:

```
#1  no Origin   HTTP 200
#2  no Origin   HTTP 200
#3  no Origin   HTTP 200
#4  Origin set  HTTP 403   <-- identical URL
#5  no Origin   HTTP 200
```

So the token is neither single-use nor expiring; the header alone causes the rejection.

Actual failing request from Chrome's network tab:

```
GET /render.key?auth=...&channel_key_id=784
Origin: http://localhost:8096
Sec-Fetch-Mode: cors
-> 403 Forbidden
```

## Scope

- **Unencrypted channels are unaffected** — they never fetch a key.
- **`/render.ts` is unaffected** — I verified the segment endpoint returns 200 with `Origin` present, so only the key endpoint needs this.

## Fix

Use the existing `internalUtils.SetPlayerHeaders` helper, which strips `Accept`, `Accept-Encoding`, `Accept-Language`, `Origin` and `Referer` while setting the player User-Agent.

This is already applied for exactly this reason elsewhere in the codebase:

- `internal/handlers/drm.go` explicitly deletes `Origin` before `proxy.Do`
- `SLHandler` calls `SetPlayerHeaders` with the comment *"Delete all browser headers"*

`RenderKeyHandler` was setting `User-Agent` directly and so missed the rest.

## Verification

Built both revisions and ran them side by side against the same account:

```
:5001 unpatched   no-Origin=200   with-Origin=403
:5002 patched     no-Origin=200   with-Origin=200
```

The previously stuck channels now play in the browser.

## Testing

- `go test ./...` passes in full.
- Added `TestSetPlayerHeadersStripsBrowserHeaders` in `internal/utils/handlers_test.go` covering the stripping, following the existing table/assert style in that file.

## Notes

- Branched from and targeted at `develop`, per CONTRIBUTING.md.
- `gofmt` reports `internal/handlers/handlers.go` as unformatted on `develop` already (an unrelated `var` block alignment). I left it alone rather than mix an unrelated reformat into this diff — happy to include it if you'd prefer.
