### PR TITLE
bug: fix catchup player redirecting to a nonexistent channel

### DIFF
--- a/web/static/internal/common.js
+++ b/web/static/internal/common.js
@@ -87,6 +87,16 @@ function styleCatchupCards() {
     }
   });
 }
+// Only the top-level channel routes /play/<id> and /catchup/<id> switch modes.
+// Nested routes such as /catchup/play/<id> or /catchup/render/<id> carry a
+// sub-route where the id would be, and must be left alone.
+function parseChannelRoute(pathname) {
+  const match = pathname.match(/^\/(play|catchup)\/([^/?#]+)\/?$/);
+  if (!match || match[2] === "play" || match[2] === "render" || match[2] === "stream") {
+    return null;
+  }
+  return { mode: match[1], id: match[2] };
+}
 function updateCatchupUI() {
   const btn = document.getElementById("catchup-toggle");
   const label = document.getElementById("catchup-toggle-label");
@@ -107,18 +117,16 @@ function updateCatchupUI() {
   }
   applyCatchupToCards();
   styleCatchupCards();
-  const path = window.location.pathname;
-  const match = path.match(/^\/(play|catchup)\/([^/?#]+)/);
-  if (match) {
-    const id = match[2];
+  const route = parseChannelRoute(window.location.pathname);
+  if (route) {
     const params = getCurrentUrlParams();
     const liveOverride = params.get("live") === "true";
     const qs = params.toString();
     const base = enabled ? "/catchup/" : "/play/";
-    const target = base + id + (qs ? "?" + qs : "");
+    const target = base + route.id + (qs ? "?" + qs : "");
     if (
-      (enabled && match[1] !== "catchup" && !liveOverride) ||
-      (!enabled && match[1] !== "play")
+      (enabled && route.mode !== "catchup" && !liveOverride) ||
+      (!enabled && route.mode !== "play")
     ) {
       window.location.replace(target);
     }
@@ -132,19 +140,14 @@ function toggleCatchupMode() {
   }
   setLocalStorageItem("catchupMode", next);
   updateCatchupUI();
-  const path = window.location.pathname;
-  const match = path.match(/^\/(play|catchup)\/([^/?#]+)/);
-  if (match) {
-    const id = match[2];
+  const route = parseChannelRoute(window.location.pathname);
+  if (route) {
     const params = getCurrentUrlParams();
-    // When manually toggling, we probably want to ignore the live override if we are switching TO catchup
-    // But if we are switching TO play, live override is redundant but harmless.
-    // If we are on Play (with live=true) and toggle ON, we should go to Catchup.
-    // So we don't check liveOverride here because user action takes precedence.
+    // Manual toggling is an explicit user action, so it overrides live=true.
     const qs = params.toString();
     const base = next ? "/catchup/" : "/play/";
-    const target = base + id + (qs ? "?" + qs : "");
-    if ((next && match[1] !== "catchup") || (!next && match[1] !== "play")) {
+    const target = base + route.id + (qs ? "?" + qs : "");
+    if ((next && route.mode !== "catchup") || (!next && route.mode !== "play")) {
       window.location.replace(target);
     }
   }

--- a/web/test/catchup_route.test.js
+++ b/web/test/catchup_route.test.js
@@ -1,0 +1,44 @@
+// Regression guard: the catchup mode toggle used to treat the sub-route in
+// /catchup/play/<id> as the channel id and redirect to /play/play, which loaded
+// a player for a channel named "play".
+const { readFileSync } = require("node:fs");
+
+beforeEach(() => {
+  // utils.js supplies getLocalStorageItem/getCurrentUrlParams used by common.js.
+  window.eval(readFileSync("static/internal/utils.js", "utf8"));
+  window.eval(readFileSync("static/internal/common.js", "utf8"));
+});
+
+describe("parseChannelRoute", () => {
+  test("parses top-level channel routes", () => {
+    expect(window.parseChannelRoute("/play/143")).toEqual({
+      mode: "play",
+      id: "143",
+    });
+    expect(window.parseChannelRoute("/catchup/143")).toEqual({
+      mode: "catchup",
+      id: "143",
+    });
+    expect(window.parseChannelRoute("/catchup/143/")).toEqual({
+      mode: "catchup",
+      id: "143",
+    });
+  });
+
+  test("ignores nested catchup sub-routes", () => {
+    expect(window.parseChannelRoute("/catchup/play/143")).toBeNull();
+    expect(window.parseChannelRoute("/catchup/render/143")).toBeNull();
+    expect(window.parseChannelRoute("/catchup/stream/143")).toBeNull();
+  });
+
+  test("ignores a bare sub-route name in the id position", () => {
+    expect(window.parseChannelRoute("/catchup/play")).toBeNull();
+    expect(window.parseChannelRoute("/play/render")).toBeNull();
+  });
+
+  test("ignores unrelated paths", () => {
+    expect(window.parseChannelRoute("/")).toBeNull();
+    expect(window.parseChannelRoute("/player/143")).toBeNull();
+    expect(window.parseChannelRoute("/premium/providers")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Catchup playback was dead from the UI. Opening a programme from the catchup page loaded a player for a channel named `play`.

The catchup mode route regex in `common.js` was unanchored:

```js
path.match(/^\/(play|catchup)\/([^/?#]+)/)
```

On `/catchup/play/143` this matched with `play` captured as the channel id, so `updateCatchupUI` redirected the page to `/play/play` and the iframe resolved to `/mpd/play`. The video element never loaded and nothing was logged to the console, so the failure was silent.

The server-rendered iframe src was correct all along (`/catchup/render/143?start=...`); the client rewrote the URL out from under it on `DOMContentLoaded`.

Both `updateCatchupUI` and `toggleCatchupMode` carried a copy of the same flawed regex, so the fix goes in one shared `parseChannelRoute` helper: anchored to the top-level `/play/<id>` and `/catchup/<id>` routes, rejecting the `play`, `render` and `stream` sub-route names.

## Testing

`web/test/catchup_route.test.js` covers the parser against the real `common.js`: top-level routes, nested sub-routes, a bare sub-route name in the id position, and unrelated paths. Two of the four cases fail against the old regex, confirming the test defends the bug.

Verified in a real browser against a local build:

- `/catchup/play/143?start=...&end=...&srno=...` now stays on its own URL, iframe resolves to `/catchup/render/143?...`
- Catchup video plays: 1806s duration, upshifts to 1920x1080, `currentTime` advances 5s over 5s
- Live playback via `/play/143` unaffected, still 1920x1080 and advancing
- Catchup toggle still redirects correctly on plain channel routes, and still honours the `live=true` override
- Full frontend suite: 131 tests, 11 suites