### PR TITLE
fix(web): filter locked similar channels

### DIFF
--- a/web/static/internal/epg.js
+++ b/web/static/internal/epg.js
@@ -82,8 +82,10 @@ function getSimilarChannels(channelsData, currentChannel, maxChannels = 12) {
 
     // Filter channels by same category and language, excluding current channel
     let similarChannels = channelsData.result.filter(channel => {
-        return channel.channel_id !== currentChannelID &&
-            (channel.channelCategoryId === currentCategory && channel.channelLanguageId === currentLanguage);
+        return !channel.requiresSubscription &&
+            channel.channel_id !== currentChannelID &&
+            channel.channelCategoryId === currentCategory &&
+            channel.channelLanguageId === currentLanguage;
     });
 
     // Shuffle the array to randomize selection

--- a/web/test/play.test.js
+++ b/web/test/play.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+const { readFileSync } = require('node:fs');
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -109,6 +110,33 @@ describe('Play Page Functions', () => {
 
     const currentChannel = getCurrentChannelInfo(channelsData, 'test-channel');
     expect(currentChannel.channel_name).toBe('Test Channel');
+  });
+
+  test('similar channels exclude channels outside the user plan', () => {
+    window.history.replaceState({}, '', '/play/current');
+    window.safeGetElementById = jest.fn(() => null);
+    window.safeGetElementsById = jest.fn(() => ({}));
+    window.getJSON = jest.fn().mockRejectedValue(new Error('skip page initialization'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    window.createElement = jest.fn();
+    window.updateNowPlayingDescription = jest.fn();
+
+    window.eval(readFileSync('static/internal/epg.js', 'utf8'));
+
+    const currentChannel = {
+      channel_id: 'current',
+      channelCategoryId: 1,
+      channelLanguageId: 1,
+    };
+    const similarChannels = getSimilarChannels({
+      result: [
+        currentChannel,
+        { channel_id: 'included', channelCategoryId: 1, channelLanguageId: 1 },
+        { channel_id: 'locked', channelCategoryId: 1, channelLanguageId: 1, requiresSubscription: true },
+      ],
+    }, currentChannel);
+
+    expect(similarChannels.map(channel => channel.channel_id)).toEqual(['included']);
   });
 
   test('getSimilarChannels filters and randomizes correctly', () => {


### PR DESCRIPTION
## Problem
Similar channel suggestions below the player included channels marked as requiring a separate subscription, leading users to streams outside their active plan.

## Fix
- Exclude channels with `requiresSubscription` from similar-channel selection.
- Add a regression test against the production `epg.js` implementation.

## Verification
- `npm test -- --watchAll=false --ci`: 11 suites, 132 tests passed
- `go test ./...`: 432 tests passed across 17 packages
- Browser smoke: mocked one entitled and one locked matching channel; only the entitled channel rendered