### PR TITLE
fix(web): suppress subscription warnings per channel

### DIFF
--- a/web/static/internal/epg.js
+++ b/web/static/internal/epg.js
@@ -83,7 +83,8 @@ function getSimilarChannels(channelsData, currentChannel, maxChannels = 12) {
     // Filter channels by same category and language, excluding current channel
     let similarChannels = channelsData.result.filter(channel => {
         return channel.channel_id !== currentChannelID &&
-            (channel.channelCategoryId === currentCategory && channel.channelLanguageId === currentLanguage);
+            channel.channelCategoryId === currentCategory &&
+            channel.channelLanguageId === currentLanguage;
     });
 
     // Shuffle the array to randomize selection
@@ -121,6 +122,8 @@ function renderSimilarChannels(similarChannels) {
             href: `/play/${channel.channel_id}`,
             className: 'card relative border border-primary bg-base-100 shadow-sm group',
             'data-channel-id': channel.channel_id,
+            'data-channel-name': channel.channel_name,
+            ...(channel.requiresSubscription ? { 'data-requires-subscription': 'true' } : {}),
             tabindex: '0'
         }, '', `
             <div class="flex flex-col items-center p-3">

--- a/web/static/internal/utils.js
+++ b/web/static/internal/utils.js
@@ -140,6 +140,69 @@ function removeLocalStorageItem(key) {
   }
 }
 
+const SUBSCRIPTION_WARNING_STORAGE_KEY = "subscriptionWarningSuppressed";
+
+function getSubscriptionWarningSuppressions() {
+  const suppressed = getLocalStorageItem(SUBSCRIPTION_WARNING_STORAGE_KEY, []);
+  return Array.isArray(suppressed) ? suppressed.filter(id => typeof id === "string") : [];
+}
+
+function isSubscriptionWarningSuppressed(channelId) {
+  return getSubscriptionWarningSuppressions().includes(String(channelId));
+}
+
+function suppressSubscriptionWarning(channelId) {
+  const id = String(channelId);
+  const suppressed = getSubscriptionWarningSuppressions();
+  if (!suppressed.includes(id)) {
+    setLocalStorageItem(SUBSCRIPTION_WARNING_STORAGE_KEY, [...suppressed, id]);
+  }
+}
+
+function initSubscriptionWarnings() {
+  const modal = safeGetElementById("locked_channel_modal", true);
+  if (!modal) return;
+
+  const message = safeGetElementById("locked-channel-message", true);
+  const suppressCheckbox = safeGetElementById("locked-channel-suppress", true);
+  const cancelButton = safeGetElementById("locked-channel-cancel", true);
+  const continueButton = safeGetElementById("locked-channel-continue", true);
+  const backdrop = safeGetElementById("locked-channel-backdrop", true);
+  let pendingHref = null;
+  let pendingChannelId = null;
+
+  const close = () => {
+    modal.classList.remove("modal-open");
+    pendingHref = null;
+    pendingChannelId = null;
+  };
+
+  document.addEventListener("click", (event) => {
+    if (event.target.closest(".favorite-btn")) return;
+    const card = event.target.closest('a.card[data-requires-subscription="true"]');
+    const channelId = card?.dataset.channelId;
+    if (!card || !channelId || isSubscriptionWarningSuppressed(channelId) || modal.classList.contains("modal-open")) return;
+
+    event.preventDefault();
+    pendingHref = card.href;
+    pendingChannelId = channelId;
+    const name = card.dataset.channelName || card.querySelector(".font-bold, .font-semibold")?.textContent?.trim() || "This channel";
+    if (message) message.textContent = `${name} may require a separate subscription. Playback may fail unless your account is entitled.`;
+    if (suppressCheckbox) suppressCheckbox.checked = false;
+    modal.classList.add("modal-open");
+  });
+
+  cancelButton?.addEventListener("click", close);
+  backdrop?.addEventListener("click", close);
+  continueButton?.addEventListener("click", () => {
+    const href = pendingHref;
+    if (suppressCheckbox?.checked && pendingChannelId) suppressSubscriptionWarning(pendingChannelId);
+    close();
+    if (href) window.location.href = href;
+  });
+}
+
+
 // URL Utilities
 /**
  * Get current URL search parameters

--- a/web/test/play.test.js
+++ b/web/test/play.test.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+const { readFileSync } = require('node:fs');
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -110,6 +111,17 @@ describe('Play Page Functions', () => {
     const currentChannel = getCurrentChannelInfo(channelsData, 'test-channel');
     expect(currentChannel.channel_name).toBe('Test Channel');
   });
+  test('suppression is shared by channel and similar-card flows', () => {
+    window.eval(readFileSync('static/internal/utils.js', 'utf8'));
+    localStorage.clear();
+
+    expect(isSubscriptionWarningSuppressed('locked')).toBe(false);
+    suppressSubscriptionWarning('locked');
+    expect(getSubscriptionWarningSuppressions()).toEqual(['locked']);
+    expect(isSubscriptionWarningSuppressed('locked')).toBe(true);
+    expect(isSubscriptionWarningSuppressed('other')).toBe(false);
+  });
+
 
   test('getSimilarChannels filters and randomizes correctly', () => {
     function getSimilarChannels(channelsData, currentChannel, maxChannels = 6) {

--- a/web/views/channel_list.html
+++ b/web/views/channel_list.html
@@ -52,7 +52,7 @@
       class="checkbox checkbox-sm checkbox-primary"
       onchange="toggleLockedChannels(this.checked)"
     />
-    <span>Only show channels included in my plan</span>
+    <span>Hide channels requiring a separate subscription</span>
     <span id="locked-channel-count" class="ml-auto text-xs text-base-content/50"></span>
   </label>
   <div id="favorite-channels-section" class="px-4 pt-6" style="display: none;">
@@ -83,7 +83,7 @@
         {{if $channel.RequiresSubscription}}
         <span
           class="badge badge-outline badge-sm mt-1.5 gap-1 text-[0.65rem] opacity-70"
-          title="Not included in your plan — requires a separate subscription"
+          title="May require a separate subscription"
         >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-2.5 w-2.5" aria-hidden="true">
             <path fill-rule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clip-rule="evenodd" />
@@ -131,8 +131,12 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
         </svg>
       </span>
-      <h3 id="locked-channel-title" class="mt-3 font-bold text-xl tracking-tight">Subscription required</h3>
+      <h3 id="locked-channel-title" class="mt-3 font-bold text-xl tracking-tight">Subscription may be required</h3>
       <p id="locked-channel-message" class="py-3 text-sm text-base-content/60"></p>
+      <label class="flex items-center justify-center gap-2 text-sm text-base-content/70">
+        <input id="locked-channel-suppress" type="checkbox" class="checkbox checkbox-sm checkbox-primary" />
+        <span>Don’t warn me again for this channel</span>
+      </label>
       <div class="modal-action grid grid-cols-2 gap-2">
         <button id="locked-channel-cancel" type="button" class="btn">Cancel</button>
         <button id="locked-channel-continue" type="button" class="btn btn-primary">Try anyway</button>
@@ -149,11 +153,7 @@
 
     function toggleLockedChannels(shouldHide) {
       document.body.classList.toggle("hide-locked-channels", shouldHide);
-      try {
-        localStorage.setItem(LOCKED_CHANNELS_STORAGE_KEY, JSON.stringify(shouldHide));
-      } catch (_) {
-        // Ignore storage failures (private mode, quota).
-      }
+      setLocalStorageItem(LOCKED_CHANNELS_STORAGE_KEY, shouldHide);
     }
 
     (() => {
@@ -170,42 +170,10 @@
         return;
       }
 
-      let stored = false;
-      try {
-        stored = JSON.parse(localStorage.getItem(LOCKED_CHANNELS_STORAGE_KEY)) === true;
-      } catch (_) {
-        stored = false;
-      }
+      const stored = getLocalStorageItem(LOCKED_CHANNELS_STORAGE_KEY, false) === true;
       toggle.checked = stored;
       toggleLockedChannels(stored);
-
-      const lockedModal = document.getElementById("locked_channel_modal");
-      const lockedMessage = document.getElementById("locked-channel-message");
-      let pendingHref = null;
-
-      const closeLockedModal = () => {
-        lockedModal.classList.remove("modal-open");
-        pendingHref = null;
-      };
-
-      document.addEventListener("click", (event) => {
-        if (event.target.closest(".favorite-btn")) return;
-        const card = event.target.closest('a.card[data-requires-subscription="true"]');
-        if (!card || lockedModal.classList.contains("modal-open")) return;
-        event.preventDefault();
-        const name = card.querySelector(".font-bold")?.textContent?.trim() || "This channel";
-        pendingHref = card.href;
-        lockedMessage.textContent = `${name} is not included in your plan and needs a separate subscription. Playback will likely fail.`;
-        lockedModal.classList.add("modal-open");
-      });
-
-      document.getElementById("locked-channel-cancel").addEventListener("click", closeLockedModal);
-      document.getElementById("locked-channel-backdrop").addEventListener("click", closeLockedModal);
-      document.getElementById("locked-channel-continue").addEventListener("click", () => {
-        const href = pendingHref;
-        closeLockedModal();
-        if (href) window.location.href = href;
-      });
+      initSubscriptionWarnings();
     })();
   </script>
 </div>

--- a/web/views/play.html
+++ b/web/views/play.html
@@ -190,11 +190,27 @@
         });
       </script>
     </div>
+    <div id="locked_channel_modal" class="modal modal-bottom sm:modal-middle" role="dialog" aria-modal="true" aria-labelledby="locked-channel-title" aria-describedby="locked-channel-message">
+      <div class="modal-box pb-[calc(1.5rem+env(safe-area-inset-bottom))] text-center">
+        <h2 id="locked-channel-title" class="font-bold text-xl tracking-tight">Subscription may be required</h2>
+        <p id="locked-channel-message" class="py-3 text-sm text-base-content/60"></p>
+        <label class="flex items-center justify-center gap-2 text-sm text-base-content/70">
+          <input id="locked-channel-suppress" type="checkbox" class="checkbox checkbox-sm checkbox-primary" />
+          <span>Don’t warn me again for this channel</span>
+        </label>
+        <div class="modal-action grid grid-cols-2 gap-2">
+          <button id="locked-channel-cancel" type="button" class="btn">Cancel</button>
+          <button id="locked-channel-continue" type="button" class="btn btn-primary">Try anyway</button>
+        </div>
+      </div>
+      <button id="locked-channel-backdrop" type="button" class="modal-backdrop" aria-label="Close subscription notice"></button>
+    </div>
     <script src="/static/internal/utils.js"></script>
     <script src="/static/internal/now_playing.js"></script>
     <script src="/static/internal/common.js"></script>
     <script src="/static/internal/epg.js"></script>
     <script src="/static/internal/remote.js"></script>
+    <script>initSubscriptionWarnings();</script>
     {{ template "footer" . }}
   </body>
 </html>


### PR DESCRIPTION
## Problem
The live-channel API marks channels as premium but does not expose a channel-to-plan entitlement mapping. Existing UI copy claimed those channels were outside the user’s plan and warned on every click, including for users with valid entitlements.

## Fix
- Store warning suppression by channel ID in localStorage.
- Apply the same suppression state to channel-list cards and similar-channel cards.
- Keep marked similar channels visible; the shared warning handles them.
- Make UI copy conditional: channels may require a separate subscription rather than asserting plan exclusion.

## Verification
- `npm test -- --watchAll=false --ci`: 11 suites, 132 tests passed.
- `npm run build`: passed.

## Limitation
Suppression is device-local and does not infer or change server-side entitlement.