### PR TITLE
fix(catchup): force Firefox HLS playback

### DIFF
--- a/internal/handlers/catchup.go
+++ b/internal/handlers/catchup.go
@@ -126,7 +126,7 @@ func CatchupHandler(c *fiber.Ctx) error {
 }
 
 func CatchupStreamHandler(c *fiber.Ctx) error {
-	id := c.Params("id")
+	id := strings.TrimSuffix(c.Params("id"), ".m3u8")
 	start := c.Query("start")
 	end := c.Query("end")
 
@@ -218,7 +218,7 @@ func CatchupRenderPlayerHandler(c *fiber.Ctx) error {
 		qualityForDrm = "high"
 	}
 
-	playURL := fmt.Sprintf("/catchup/stream/%s?start=%s&end=%s&srno=%s", id, start, end, srno)
+	playURL := fmt.Sprintf("/catchup/stream/%s.m3u8?start=%s&end=%s&srno=%s", id, start, end, srno)
 	if quality != "" {
 		playURL += "&q=" + quality
 	}

--- a/internal/handlers/catchup_fixes_test.go
+++ b/internal/handlers/catchup_fixes_test.go
@@ -1,6 +1,19 @@
 package handlers
 
-import "testing"
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jiotv-go/jiotv_go/v3/pkg/secureurl"
+	"github.com/jiotv-go/jiotv_go/v3/pkg/store"
+	"github.com/jiotv-go/jiotv_go/v3/pkg/television"
+	pkgUtils "github.com/jiotv-go/jiotv_go/v3/pkg/utils"
+)
 
 func TestHdneaCacheKey(t *testing.T) {
 	tests := []struct {
@@ -49,6 +62,70 @@ func TestHdneaCacheKey(t *testing.T) {
 	catchupKey := hdneaCacheKey("143", "https://example.com/Catchup_Fallback/index.m3u8")
 	if liveKey == catchupKey {
 		t.Errorf("live key (%q) and catchup key (%q) must not be equal", liveKey, catchupKey)
+	}
+}
+
+func TestRenderTSHandlerUsesCatchupTokenCache(t *testing.T) {
+	const channelID = "143"
+	const liveToken = "live-token"
+	const catchupToken = "catchup-token"
+
+	var receivedToken string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie, _ := r.Cookie("__hdnea__")
+		if cookie == nil {
+			receivedToken = ""
+		} else {
+			receivedToken = cookie.Value
+		}
+		if receivedToken != catchupToken {
+			http.Error(w, "wrong token", http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte("segment"))
+	}))
+	defer upstream.Close()
+	cleanupStore, err := store.SetupTestPathPrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupStore()
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	previousTV, previousLog := TV, pkgUtils.Log
+	pkgUtils.Log = log.New(os.Stderr, "", 0)
+	TV = television.New(nil)
+	secureurl.Init()
+	defer func() {
+		TV = previousTV
+		pkgUtils.Log = previousLog
+		renderHDNEACache.Delete(channelID)
+		renderHDNEACache.Delete(channelID + "|catchup")
+	}()
+
+	streamURL := upstream.URL + "/Catchup_Fallback/segment.ts?__hdnea__=" + catchupToken
+	setCachedHDNEA(channelID, liveToken)
+	setCachedHDNEA(hdneaCacheKey(channelID, streamURL), catchupToken)
+
+	auth, err := secureurl.EncryptURL(streamURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := fiber.New()
+	app.Get("/render.ts", RenderTSHandler)
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/render.ts?auth="+url.QueryEscape(auth)+"&channel_key_id="+channelID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	if receivedToken != catchupToken {
+		t.Errorf("upstream __hdnea__ cookie = %q, want %q", receivedToken, catchupToken)
 	}
 }
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -933,8 +933,9 @@ func RenderTSHandler(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Always prefer a freshly cached HDNEA token if available
-	cachedHDNEA := getCachedHDNEA(channelID)
+	// Cache tokens by stream kind: catchup and live ACLs are incompatible.
+	hdneaKey := hdneaCacheKey(channelID, decoded_url)
+	cachedHDNEA := getCachedHDNEA(hdneaKey)
 	if cachedHDNEA != "" {
 		c.Request().Header.SetCookie("__hdnea__", cachedHDNEA)
 		// We should also replace the token in the URL if it's there

--- a/pkg/television/television.go
+++ b/pkg/television/television.go
@@ -2169,7 +2169,6 @@ func (tv *Television) GetCatchupURL(channelID, srno, start, end string) (*LiveUR
 				utils.Log.Printf("Retrying the catchup request (attempt %d/%d)...", i+1, maxRetries)
 				continue
 			}
-			utils.Log.Panicln(err)
 			return nil, err
 		}
 		break
@@ -2194,7 +2193,6 @@ func (tv *Television) GetCatchupURL(channelID, srno, start, end string) (*LiveUR
 
 	var result LiveURLOutput
 	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		utils.Log.Panicln(err)
 		return nil, err
 	}
 

--- a/pkg/television/television_test.go
+++ b/pkg/television/television_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/jiotv-go/jiotv_go/v3/pkg/secureurl"
 	"github.com/jiotv-go/jiotv_go/v3/pkg/store"
 	"github.com/jiotv-go/jiotv_go/v3/pkg/utils"
+	"github.com/valyala/fasthttp"
 )
 
 var (
@@ -642,4 +644,17 @@ func TestLoadAndCacheCustomChannels(t *testing.T) {
 			t.Errorf("Expected channel ID to remain 'cc_already_prefixed', got '%s'", channel.ID)
 		}
 	})
+}
+
+func TestGetCatchupURLReturnsNetworkError(t *testing.T) {
+	tv := &Television{
+		Headers: map[string]string{},
+		Client: &fasthttp.Client{Dial: func(string) (net.Conn, error) {
+			return nil, fmt.Errorf("forced dial failure")
+		}},
+	}
+
+	if _, err := tv.GetCatchupURL("180", "260810180045", "1786371900000", "1786372200000"); err == nil {
+		t.Fatal("GetCatchupURL() error = nil, want network error")
+	}
 }


### PR DESCRIPTION
## Problem
Firefox treated the extensionless `/catchup/stream/:id` source as native media. It rejects `application/vnd.apple.mpegurl`, so Flowplayer failed before HLS.js could attach with `Failed to init decoder`.

## Changes
- Mark catchup player sources as `.m3u8`; the handler accepts both suffixed and existing extensionless requests.
- Separate live and catchup HDNEA cache keys so one ACL cannot overwrite the other.
- Return catchup transport and JSON errors instead of panicking.

## Verification
- `go test ./...` (434 tests)
- `go build -o build/jiotv_go .`
- Firefox console reproduction: extensionless source rejected HLS MIME before decoder initialization.
- Browser playback smoke test: player source uses `.m3u8`; playlist/segments return `200`/`206` and playback advances without a media error.