### PR TITLE
feat: expose DRM key URL in channels API

### DIFF
--- a/docs/usage/paths.md
+++ b/docs/usage/paths.md
@@ -47,7 +47,7 @@ This section provides information about the API endpoints that JioTV Go offers. 
 ### Get Channels data
 
 - **Path**: `/channels`
-  Discover the complete list of available channels in JSON format.
+  Discover the complete list of available channels in JSON format. DRM channels include `channel_url` for the MPD manifest and `key_url` for the `/live/key/:channel_id` license path.
 
 ## TV Endpoints
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1000,6 +1000,19 @@ func RenderTSHandler(c *fiber.Ctx) error {
 	return nil
 }
 
+func setChannelPlaybackURLs(channels []television.Channel, hostURL string) {
+	for i := range channels {
+		if EnableDRM && utils.ContainsString(channels[i].ID, drmList) {
+			channels[i].URL = fmt.Sprintf("%s/live/mpd/%s", hostURL, channels[i].ID)
+			channels[i].KeyURL = fmt.Sprintf("%s/live/key/%s", hostURL, channels[i].ID)
+			continue
+		}
+
+		channels[i].URL = fmt.Sprintf("%s/live/%s", hostURL, channels[i].ID)
+		channels[i].KeyURL = ""
+	}
+}
+
 // ChannelsHandler fetch all channels from JioTV API
 // Also to generate M3U playlist
 func ChannelsHandler(c *fiber.Ctx) error {
@@ -1026,13 +1039,7 @@ func ChannelsHandler(c *fiber.Ctx) error {
 		return c.SendStream(strings.NewReader(m3uContent))
 	}
 
-	for i, channel := range apiResponse.Result {
-		if EnableDRM && utils.ContainsString(channel.ID, drmList) {
-			apiResponse.Result[i].URL = fmt.Sprintf("%s/live/mpd/%s", hostURL, channel.ID)
-		} else {
-			apiResponse.Result[i].URL = fmt.Sprintf("%s/live/%s", hostURL, channel.ID)
-		}
-	}
+	setChannelPlaybackURLs(apiResponse.Result, hostURL)
 
 	return c.JSON(apiResponse)
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -323,6 +323,38 @@ func TestChannelsHandler(t *testing.T) {
 		})
 	}
 }
+func TestSetChannelPlaybackURLs(t *testing.T) {
+	origEnableDRM := EnableDRM
+	origDRMList := drmList
+	defer func() {
+		EnableDRM = origEnableDRM
+		drmList = origDRMList
+	}()
+
+	EnableDRM = true
+	drmList = []string{"143"}
+	channels := []television.Channel{{ID: "143"}, {ID: "101"}}
+
+	setChannelPlaybackURLs(channels, "http://localhost:5001")
+
+	if got, want := channels[0].URL, "http://localhost:5001/live/mpd/143"; got != want {
+		t.Errorf("DRM channel URL = %q, want %q", got, want)
+	}
+	if got, want := channels[0].KeyURL, "http://localhost:5001/live/key/143"; got != want {
+		t.Errorf("DRM channel key URL = %q, want %q", got, want)
+	}
+	if got := channels[1].KeyURL; got != "" {
+		t.Errorf("non-DRM channel key URL = %q, want empty", got)
+	}
+
+	body, err := json.Marshal(channels[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"key_url":"http://localhost:5001/live/key/143"`) {
+		t.Errorf("DRM channel JSON missing key_url: %s", body)
+	}
+}
 
 func TestPlayHandler(t *testing.T) {
 	type args struct {

--- a/pkg/television/types.go
+++ b/pkg/television/types.go
@@ -23,6 +23,7 @@ type Channel struct {
 	ID                 string `json:"channel_id"`
 	Name               string `json:"channel_name"`
 	URL                string `json:"channel_url"`
+	KeyURL             string `json:"key_url,omitempty"`
 	LogoURL            string `json:"logoUrl"`
 	Category           int    `json:"channelCategoryId"`
 	Language           int    `json:"channelLanguageId"`


### PR DESCRIPTION
## Summary
- add `key_url` to DRM channel entries returned by `/channels`
- keep non-DRM entries backward-compatible by omitting the field
- document the channel response contract and add regression coverage

## Verification
- `go test ./...` (435 tests)
- `go build -o /tmp/jiotv_go ./`
- `git diff --check`