### PR TITLE
fix(security): resolve alerts 9 and 62

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"net/url"
 	"os"
 	"regexp"
@@ -1229,11 +1231,13 @@ func PlayHandler(c *fiber.Ctx) error {
 	} else {
 		player_url = "/player/" + id + "?q=" + quality
 	}
+	playerURLJSON, _ := json.Marshal(player_url)
 	internalUtils.SetCacheHeader(c, 3600)
 	return c.Render("views/play", fiber.Map{
-		"Title":      Title,
-		"player_url": player_url,
-		"ChannelID":  id,
+		"Title":         Title,
+		"player_url":    player_url,
+		"player_url_js": template.JS(playerURLJSON),
+		"ChannelID":     id,
 	})
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4626,9 +4626,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/views/play.html
+++ b/web/views/play.html
@@ -24,7 +24,6 @@
               id="playerIframe"
               class="absolute top-0 left-0 bottom-0 right-0 w-full h-full"
               src="{{ .player_url }}"
-              data-base-src="{{ .player_url }}"
               width="100%"
               height="100%"
               webkitAllowFullScreen
@@ -106,6 +105,7 @@
         const channelId = {{ printf "%q" .ChannelID }};
         let current43Mode = false;
         let playerModeIsHD = false;
+        const playerBaseURL = {{ .player_url_js }};
 
         // SVG icon constants
         const DOWN_ARROW_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path fill-rule="evenodd" d="M12 2.25a.75.75 0 0 1 .75.75v16.19l6.22-6.22a.75.75 0 1 1 1.06 1.06l-7.5 7.5a.75.75 0 0 1-1.06 0l-7.5-7.5a.75.75 0 1 1 1.06-1.06l6.22 6.22V3a.75.75 0 0 1 .75-.75Z" clip-rule="evenodd" /></svg>';
@@ -152,13 +152,12 @@
             return;
           }
 
-          const baseSrc = playerIframe.getAttribute("data-base-src");
-          if (!baseSrc) {
+          if (!playerBaseURL) {
             return;
           }
 
           const playerModeParam = playerModeIsHD ? "hd" : "auto";
-          const parsedUrl = new URL(baseSrc, window.location.origin);
+          const parsedUrl = new URL(playerBaseURL, window.location.origin);
           parsedUrl.searchParams.set("pm", playerModeParam);
 
           playerIframe.src = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;


### PR DESCRIPTION
## Summary
- patch transitive development-only `js-yaml` to 3.15.1 for Dependabot alert 62
- serialize the server-generated player URL into JavaScript and remove the DOM-derived URL source for CodeQL alert 9

## Verification
- `go test ./...`
- `cd web && npm ci && npm audit --package-lock-only --audit-level=high`
- `cd web && npm run build`
- `cd web && npm test -- --watchAll=false --ci`
- browser smoke test: `/play/143` preserves its iframe path; HD mode sets `pm=hd`; `data-base-src` is absent