### PR TITLE
fix(web): faster DRM channel loading and a working Now Playing guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ jiotv.json
 # MdBook Docs
 docs/book/
 book/
+
+# pnpm files
+pnpm*

--- a/internal/handlers/drm.go
+++ b/internal/handlers/drm.go
@@ -64,6 +64,62 @@ var (
 	drmMpdCacheTTL = 30 * time.Second
 )
 
+// The proxied Broadpeak MPDs timestamp their segment timeline with the CDN's
+// own clock (publishTime), which can differ from the machine clock by minutes.
+// /dashtime is the UTCTiming clock source players sync to, so it must report
+// the CDN's clock - not the machine's - or players compute the live edge far
+// from where the segments actually are and playback stalls for the duration
+// of the skew. These hold the last observed CDN publishTime so
+// DASHTimeHandler can serve an extrapolated CDN clock. Note the cache is
+// global across channels: if two channels' CDNs run different clocks, an
+// interleaved fetch of one could briefly serve the wrong time to the other.
+// This self-corrects because each MPD fetch refreshes the cache and players
+// resolve /dashtime immediately after their own MPD fetch.
+var (
+	cdnClockMu          sync.Mutex
+	cdnPublishTime      time.Time
+	cdnPublishFetchedAt time.Time
+)
+
+// publishTimeRe extracts the publishTime attribute from live MPD bodies.
+var publishTimeRe = regexp.MustCompile(`publishTime="([^"]+)"`)
+
+// recordCdnPublishTime caches the upstream CDN clock observed from an MPD fetch.
+func recordCdnPublishTime(publishTime time.Time) {
+	cdnClockMu.Lock()
+	defer cdnClockMu.Unlock()
+	cdnPublishTime = publishTime
+	cdnPublishFetchedAt = time.Now()
+}
+
+// cdnNow returns the CDN's current clock, extrapolated from the last observed
+// publishTime, and whether any observation exists yet.
+func cdnNow() (time.Time, bool) {
+	cdnClockMu.Lock()
+	defer cdnClockMu.Unlock()
+	if cdnPublishFetchedAt.IsZero() {
+		return time.Time{}, false
+	}
+	elapsed := time.Since(cdnPublishFetchedAt)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return cdnPublishTime.Add(elapsed), true
+}
+
+// extractPublishTime parses the publishTime attribute from a DASH MPD body.
+func extractPublishTime(body []byte) (time.Time, bool) {
+	m := publishTimeRe.FindSubmatch(body)
+	if len(m) < 2 {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, string(m[1]))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
 type drmMpdCacheEntry struct {
 	Output    *DrmMpdOutput
 	UpdatedAt time.Time
@@ -361,13 +417,13 @@ func buildDrmMpdOutput(liveResult *television.LiveURLOutput, channelID, quality 
 		return nil, err
 	}
 	tv_url_split := strings.Split(parsedTvUrl.Path, "/")
-	tv_url_path, err := secureurl.EncryptURL(strings.Join(tv_url_split[:len(tv_url_split)-1], "/") + "/")
+	tv_url_path, err := secureurl.EncryptURLDeterministic(strings.Join(tv_url_split[:len(tv_url_split)-1], "/") + "/")
 	if err != nil {
 		utils.Log.Panicln(err)
 		return nil, err
 	}
 
-	tv_url_host, err := secureurl.EncryptURL(parsedTvUrl.Host)
+	tv_url_host, err := secureurl.EncryptURLDeterministic(parsedTvUrl.Host)
 	if err != nil {
 		utils.Log.Panicln(err)
 		return nil, err
@@ -555,6 +611,11 @@ func MpdHandler(c *fiber.Ctx) error {
 	// CRITICAL: Refresh credentials before proxying MPD
 	EnsureFreshCredentials()
 
+	// Capture the local server URL before proxying: proxy.Do rewrites the
+	// request URI to the upstream CDN, after which c.Hostname()/c.Protocol()
+	// would return the CDN's host and scheme instead of ours.
+	localServerURL := c.Protocol() + "://" + c.Hostname()
+
 	channelID := c.Query("channel_id")
 	quality := c.Query("q")
 	proxyUrl := c.Query("auth")
@@ -590,12 +651,12 @@ func MpdHandler(c *fiber.Ctx) error {
 	proxyHost := parsedUrl.Host
 	pathParts := strings.Split(parsedUrl.Path, "/")
 	basePath := strings.Join(pathParts[:len(pathParts)-1], "/") + "/"
-	encProxyHost, err := secureurl.EncryptURL(proxyHost)
+	encProxyHost, err := secureurl.EncryptURLDeterministic(proxyHost)
 	if err != nil {
 		utils.Log.Panicln(err)
 		return err
 	}
-	encProxyPath, err := secureurl.EncryptURL(basePath)
+	encProxyPath, err := secureurl.EncryptURLDeterministic(basePath)
 	if err != nil {
 		utils.Log.Panicln(err)
 		return err
@@ -610,7 +671,7 @@ func MpdHandler(c *fiber.Ctx) error {
 
 	dashBaseURL := fmt.Sprintf("/render.dash/host/%s/path/%s", encProxyHost, encProxyPath)
 	if cachedHDNEA != "" {
-		encHDNEA, encErr := secureurl.EncryptURL("__hdnea__=" + cachedHDNEA)
+		encHDNEA, encErr := secureurl.EncryptURLDeterministic("__hdnea__=" + cachedHDNEA)
 		if encErr == nil {
 			dashBaseURL = fmt.Sprintf("/render.dash/host/%s/path/%s/hdnea/%s", encProxyHost, encProxyPath, encHDNEA)
 		}
@@ -633,7 +694,12 @@ func MpdHandler(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Handle 403/401 auth failures by stripping HDNEA and retrying
+	// Handle 403/401 auth failures by stripping HDNEA and retrying.
+	// HDNEA tokens are CDN-managed and expire independently of the JioTV
+	// session tokens, so the first retry drops the stale HDNEA and lets the
+	// CDN issue fresh auth. A full credential refresh is only attempted if
+	// that still fails, avoiding a blocking token refresh on every expired
+	// manifest request.
 	statusCode := c.Response().StatusCode()
 	if statusCode == fiber.StatusForbidden || statusCode == fiber.StatusUnauthorized {
 		if os.Getenv("JIOTV_DEBUG") == "true" {
@@ -642,7 +708,6 @@ func MpdHandler(c *fiber.Ctx) error {
 
 		// Reset response to allow retry
 		c.Response().Reset()
-		ForceRefreshCredentials()
 
 		// Strip HDNEA token and retry - CDN will provide fresh auth
 		// HDNEA tokens are CDN-managed and expire, so requesting without them
@@ -664,6 +729,22 @@ func MpdHandler(c *fiber.Ctx) error {
 			return err
 		}
 
+		// If stripping HDNEA did not help, the JioTV session tokens may have
+		// expired; refresh them and retry once more.
+		if retryStatus := c.Response().StatusCode(); retryStatus == fiber.StatusForbidden || retryStatus == fiber.StatusUnauthorized {
+			if os.Getenv("JIOTV_DEBUG") == "true" {
+				utils.Log.Printf("[DEBUG] MpdHandler retry still %d - forcing credential refresh", retryStatus)
+			}
+			c.Response().Reset()
+			ForceRefreshCredentials()
+			if err := proxy.Do(c, strippedUrl, TV.Client); err != nil {
+				if os.Getenv("JIOTV_DEBUG") == "true" {
+					utils.Log.Printf("[DEBUG] MpdHandler forced-refresh retry failed: %v", err)
+				}
+				return err
+			}
+		}
+
 		if os.Getenv("JIOTV_DEBUG") == "true" {
 			utils.Log.Printf("[DEBUG] MpdHandler retry - new status: %d", c.Response().StatusCode())
 		}
@@ -679,7 +760,7 @@ func MpdHandler(c *fiber.Ctx) error {
 
 	// If we got a fresh __hdnea__ from upstream, update dashBaseURL with it
 	if upstreamHDNEA != "" {
-		encHDNEA, encErr := secureurl.EncryptURL("__hdnea__=" + upstreamHDNEA)
+		encHDNEA, encErr := secureurl.EncryptURLDeterministic("__hdnea__=" + upstreamHDNEA)
 		if encErr == nil {
 			dashBaseURL = fmt.Sprintf("/render.dash/host/%s/path/%s/hdnea/%s", encProxyHost, encProxyPath, encHDNEA)
 		}
@@ -701,6 +782,33 @@ func MpdHandler(c *fiber.Ctx) error {
 		}
 	}
 	resBody := c.Response().Body()
+
+	// Record the upstream CDN clock so /dashtime can report it: the segment
+	// timeline in this MPD is stamped in CDN time, and players must sync to
+	// that clock to find the live edge.
+	if pt, ok := extractPublishTime(resBody); ok {
+		recordCdnPublishTime(pt)
+	}
+
+	// Inject a UTCTiming element pointing at the local /dashtime clock source.
+	// JioTV's Broadpeak MPDs carry no UTCTiming element and use
+	// availabilityStartTime="1970-01-01T00:00:00Z", so without a clock source
+	// players compute the live edge from the client clock. A skewed client
+	// clock makes them hunt for the live edge and pre-roll a large chunk of
+	// the DVR window before playback can start. Serving the clock from the
+	// server fixes this for every client (Shaka, IPTV apps, ExoPlayer...),
+	// not just the browser player.
+	if !bytes.Contains(resBody, []byte("<UTCTiming")) {
+		utcTiming := fmt.Sprintf(
+			`<UTCTiming schemeIdUri="urn:mpeg:dash:utc:http-xsdate:2014" value="%s/dashtime"/>`,
+			localServerURL,
+		)
+		mpdTagPattern := regexp.MustCompile(`<MPD[^>]*>`)
+		resBody = mpdTagPattern.ReplaceAllFunc(resBody, func(match []byte) []byte {
+			return append(append([]byte{}, match...), []byte(utcTiming)...)
+		})
+	}
+
 	basePathPattern := `<BaseURL>(.*)<\/BaseURL>`
 	re := regexp.MustCompile(basePathPattern)
 	// check for match
@@ -820,7 +928,12 @@ func DashHandler(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Handle 403/401 auth failures with retry mechanism (AGGRESSIVE REFRESH)
+	// Handle 403/401 auth failures by clearing the stale HDNEA cookie and
+	// retrying. Segment requests carry only the CDN's __hdnea__ cookie (not
+	// the JioTV session tokens), so an expired token is a CDN auth problem:
+	// dropping the cookie lets the CDN issue fresh auth without the cost of a
+	// blocking token refresh on every expired segment request. A full refresh
+	// is attempted only if the retry still fails.
 	statusCode := c.Response().StatusCode()
 	if statusCode == fiber.StatusForbidden || statusCode == fiber.StatusUnauthorized {
 		if os.Getenv("JIOTV_DEBUG") == "true" {
@@ -829,7 +942,6 @@ func DashHandler(c *fiber.Ctx) error {
 
 		// Reset response to allow retry
 		c.Response().Reset()
-		ForceRefreshCredentials()
 
 		// Clear HDNEA cookie - expired token causes 403
 		// CDN will provide fresh HDNEA in the response
@@ -840,6 +952,22 @@ func DashHandler(c *fiber.Ctx) error {
 				utils.Log.Printf("[DEBUG] DashHandler retry failed: %v", err)
 			}
 			return err
+		}
+
+		// If clearing the cookie did not help, the JioTV session tokens may
+		// have expired; refresh them and retry once more.
+		if retryStatus := c.Response().StatusCode(); retryStatus == fiber.StatusForbidden || retryStatus == fiber.StatusUnauthorized {
+			if os.Getenv("JIOTV_DEBUG") == "true" {
+				utils.Log.Printf("[DEBUG] DashHandler retry still %d - forcing credential refresh", retryStatus)
+			}
+			c.Response().Reset()
+			ForceRefreshCredentials()
+			if err := proxy.Do(c, proxyUrl, TV.Client); err != nil {
+				if os.Getenv("JIOTV_DEBUG") == "true" {
+					utils.Log.Printf("[DEBUG] DashHandler forced-refresh retry failed: %v", err)
+				}
+				return err
+			}
 		}
 
 		if os.Getenv("JIOTV_DEBUG") == "true" {

--- a/internal/handlers/drm_retry_test.go
+++ b/internal/handlers/drm_retry_test.go
@@ -1,0 +1,399 @@
+package handlers
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jiotv-go/jiotv_go/v3/pkg/secureurl"
+	"github.com/jiotv-go/jiotv_go/v3/pkg/store"
+	"github.com/jiotv-go/jiotv_go/v3/pkg/television"
+	pkgUtils "github.com/jiotv-go/jiotv_go/v3/pkg/utils"
+	"github.com/valyala/fasthttp"
+)
+
+// TestDashHandlerRecoversFrom403WithoutForcedRefresh verifies the per-segment
+// 403 retry contract. Segment requests carry only the CDN's __hdnea__ cookie
+// (never the JioTV session tokens), so a 403 means CDN auth expired: the
+// handler must clear the stale cookie and retry immediately, without the
+// blocking ForceRefreshCredentials() that used to run on every expired
+// segment. That blocking refresh is what turned a handful of expiring HDNEA
+// tokens into hundreds of slow segment requests during DRM channel loading.
+func TestDashHandlerRecoversFrom403WithoutForcedRefresh(t *testing.T) {
+	const staleToken = "stale-hdnea-token"
+
+	var mu sync.Mutex
+	upstreamHits := 0
+	firstRequestHadCookie := false
+	retryCarriedCookie := false
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		upstreamHits++
+		hit := upstreamHits
+		mu.Unlock()
+
+		if hit == 1 {
+			// Simulate an expired CDN token: the first request carries the
+			// stale __hdnea__ cookie and is rejected with 403.
+			cookie, err := r.Cookie("__hdnea__")
+			if err == nil && cookie.Value == staleToken {
+				mu.Lock()
+				firstRequestHadCookie = true
+				mu.Unlock()
+			}
+			http.Error(w, "expired token", http.StatusForbidden)
+			return
+		}
+		// The retry must have had the stale cookie cleared.
+		if cookie, err := r.Cookie("__hdnea__"); err == nil && cookie.Value != "" {
+			mu.Lock()
+			retryCarriedCookie = true
+			mu.Unlock()
+		}
+		_, _ = w.Write([]byte("segment-data"))
+	}))
+	defer upstream.Close()
+
+	cleanupStore, err := store.SetupTestPathPrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupStore()
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	var logBuf bytes.Buffer
+	previousTV, previousLog := TV, pkgUtils.Log
+	pkgUtils.Log = log.New(&logBuf, "", 0)
+	TV = &television.Television{
+		Client: &fasthttp.Client{TLSConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	secureurl.Init()
+	defer func() {
+		TV = previousTV
+		pkgUtils.Log = previousLog
+		nextCredentialValidationTime = time.Time{}
+	}()
+
+	t.Setenv("JIOTV_DEBUG", "true")
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encHost, err := secureurl.EncryptURL(upstreamURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encPath, err := secureurl.EncryptURL("/cdn/path/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encHdnea, err := secureurl.EncryptURL("__hdnea__=" + staleToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := fiber.New()
+	app.Use("/render.dash", DashHandler)
+
+	requestURL := fmt.Sprintf(
+		"/render.dash/host/%s/path/%s/hdnea/%s/segment.m4s",
+		encHost, encPath, encHdnea,
+	)
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, requestURL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (body: %s)", response.StatusCode, http.StatusOK, body)
+	}
+	if string(body) != "segment-data" {
+		t.Errorf("body = %q, want %q", body, "segment-data")
+	}
+
+	mu.Lock()
+	hits, firstCookie, cookieSeen := upstreamHits, firstRequestHadCookie, retryCarriedCookie
+	mu.Unlock()
+	if hits != 2 {
+		t.Errorf("upstream hits = %d, want 2 (original request + one retry)", hits)
+	}
+	if !firstCookie {
+		t.Errorf("first upstream request did not carry the stale __hdnea__ cookie")
+	}
+	if cookieSeen {
+		t.Errorf("retry request still carried the stale __hdnea__ cookie")
+	}
+	if strings.Contains(logBuf.String(), "FORCED token refresh") {
+		t.Errorf("retry triggered a blocking credential refresh:\n%s", logBuf.String())
+	}
+}
+
+// TestMpdHandlerProducesStableSegmentURLs verifies that repeated manifest
+// fetches rewrite <BaseURL> to byte-identical /render.dash URLs. Segment URLs
+// used to be re-encrypted with a random IV on every MpdHandler call, so each
+// live manifest refresh changed the URL identity of every buffered segment and
+// Shaka re-downloaded them - multiplying the requests needed before playback
+// could start.
+func TestMpdHandlerProducesStableSegmentURLs(t *testing.T) {
+	const hdneaToken = "hdnea-token-1"
+	const mpdBody = `<MPD type="dynamic"><Period><BaseURL>https://cdn.example.com/cdn/</BaseURL></Period></MPD>`
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/dash+xml")
+		http.SetCookie(w, &http.Cookie{Name: "__hdnea__", Value: hdneaToken, Path: "/"})
+		_, _ = w.Write([]byte(mpdBody))
+	}))
+	defer upstream.Close()
+
+	cleanupStore, err := store.SetupTestPathPrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupStore()
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	previousTV, previousLog := TV, pkgUtils.Log
+	pkgUtils.Log = log.New(io.Discard, "", 0)
+	TV = &television.Television{
+		Client: &fasthttp.Client{TLSConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	secureurl.Init()
+	defer func() {
+		TV = previousTV
+		pkgUtils.Log = previousLog
+		nextCredentialValidationTime = time.Time{}
+	}()
+
+	encURL, err := secureurl.EncryptURL(upstream.URL + "/cdn/stream.mpd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := fiber.New()
+	app.Use("/render.mpd", MpdHandler)
+
+	baseURLPattern := regexp.MustCompile(`<BaseURL>(.*?)</BaseURL>`)
+	fetchBaseURL := func() string {
+		response, err := app.Test(httptest.NewRequest(http.MethodGet, "/render.mpd?auth="+encURL, nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body: %s)", response.StatusCode, http.StatusOK, body)
+		}
+		match := baseURLPattern.FindSubmatch(body)
+		if len(match) != 2 {
+			t.Fatalf("no <BaseURL> found in rewritten MPD: %s", body)
+		}
+		return string(match[1])
+	}
+
+	first := fetchBaseURL()
+	second := fetchBaseURL()
+
+	if first == "" {
+		t.Fatal("first BaseURL is empty")
+	}
+	if !strings.HasPrefix(first, "/render.dash/host/") {
+		t.Errorf("first BaseURL = %q, want /render.dash/host/ prefix", first)
+	}
+	if first != second {
+		t.Errorf("BaseURL changed between manifest refreshes:\nfirst:  %s\nsecond: %s\n\nShaka treats a changed segment URL as a new segment and re-downloads it.", first, second)
+	}
+}
+
+// TestMpdHandlerInjectsUTCTiming verifies the server adds a UTCTiming element
+// to live manifests. JioTV MPDs have no UTCTiming and use an epoch
+// availabilityStartTime, so without a clock source clients compute the live
+// edge from their own (possibly skewed) clock and pre-roll a large chunk of
+// the DVR window before playback starts.
+func TestMpdHandlerInjectsUTCTiming(t *testing.T) {
+	const mpdWithoutTiming = `<MPD type="dynamic" availabilityStartTime="1970-01-01T00:00:00Z"><Period><BaseURL>https://cdn.example.com/cdn/</BaseURL></Period></MPD>`
+	const mpdWithTiming = `<MPD type="dynamic"><UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="https://cdn.example.com/time"/><Period><BaseURL>https://cdn.example.com/cdn/</BaseURL></Period></MPD>`
+
+	tests := []struct {
+		name         string
+		upstreamBody string
+		wantInjected bool
+		wantNotDupl  bool
+	}{
+		{
+			name:         "inject when manifest has no UTCTiming",
+			upstreamBody: mpdWithoutTiming,
+			wantInjected: true,
+		},
+		{
+			name:         "do not duplicate an existing UTCTiming",
+			upstreamBody: mpdWithTiming,
+			wantNotDupl:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/dash+xml")
+				_, _ = w.Write([]byte(tt.upstreamBody))
+			}))
+			defer upstream.Close()
+
+			cleanupStore, err := store.SetupTestPathPrefix()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanupStore()
+			if err := store.Init(); err != nil {
+				t.Fatal(err)
+			}
+
+			previousTV, previousLog := TV, pkgUtils.Log
+			pkgUtils.Log = log.New(io.Discard, "", 0)
+			TV = &television.Television{
+				Client: &fasthttp.Client{TLSConfig: &tls.Config{InsecureSkipVerify: true}},
+			}
+			secureurl.Init()
+			defer func() {
+				TV = previousTV
+				pkgUtils.Log = previousLog
+				nextCredentialValidationTime = time.Time{}
+			}()
+
+			encURL, err := secureurl.EncryptURL(upstream.URL + "/cdn/stream.mpd")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			app := fiber.New()
+			app.Use("/render.mpd", MpdHandler)
+
+			response, err := app.Test(httptest.NewRequest(http.MethodGet, "/render.mpd?auth="+encURL, nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d (body: %s)", response.StatusCode, http.StatusOK, body)
+			}
+
+			if tt.wantInjected {
+				if !bytes.Contains(body, []byte(`urn:mpeg:dash:utc:http-xsdate:2014`)) {
+					t.Errorf("rewritten MPD has no injected UTCTiming element:\n%s", body)
+				}
+				if !bytes.Contains(body, []byte(`/dashtime`)) {
+					t.Errorf("injected UTCTiming does not point at /dashtime:\n%s", body)
+				}
+			}
+			if tt.wantNotDupl {
+				if count := bytes.Count(body, []byte(`<UTCTiming`)); count != 1 {
+					t.Errorf("rewritten MPD contains %d UTCTiming elements, want 1 (existing preserved):\n%s", count, body)
+				}
+			}
+		})
+	}
+}
+
+// TestMpdHandlerRecordsCDNClock verifies the wiring between MpdHandler and the
+// /dashtime clock source: proxying a live MPD must cache its publishTime so
+// DASHTimeHandler can serve the CDN's clock instead of the machine's.
+func TestMpdHandlerRecordsCDNClock(t *testing.T) {
+	const publishTime = "2026-08-12T20:15:49.537686Z"
+	const mpdBody = `<MPD type="dynamic" publishTime="` + publishTime + `"><Period><BaseURL>https://cdn.example.com/cdn/</BaseURL></Period></MPD>`
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/dash+xml")
+		_, _ = w.Write([]byte(mpdBody))
+	}))
+	defer upstream.Close()
+
+	cleanupStore, err := store.SetupTestPathPrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupStore()
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	previousTV, previousLog := TV, pkgUtils.Log
+	pkgUtils.Log = log.New(io.Discard, "", 0)
+	TV = &television.Television{
+		Client: &fasthttp.Client{TLSConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	secureurl.Init()
+	defer func() {
+		TV = previousTV
+		pkgUtils.Log = previousLog
+		nextCredentialValidationTime = time.Time{}
+	}()
+
+	// Isolate the global CDN clock cache.
+	origPT, origFA := cdnPublishTime, cdnPublishFetchedAt
+	defer func() {
+		cdnClockMu.Lock()
+		defer cdnClockMu.Unlock()
+		cdnPublishTime, cdnPublishFetchedAt = origPT, origFA
+	}()
+
+	encURL, err := secureurl.EncryptURL(upstream.URL + "/cdn/stream.mpd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := fiber.New()
+	app.Use("/render.mpd", MpdHandler)
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/render.mpd?auth="+encURL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if _, err := io.ReadAll(response.Body); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+
+	cdn, ok := cdnNow()
+	if !ok {
+		t.Fatal("cdnNow() reports no recorded CDN clock after a successful MPD proxy")
+	}
+	want := time.Date(2026, 8, 12, 20, 15, 49, 537686000, time.UTC)
+	if cdn.Before(want) {
+		t.Errorf("cached CDN clock %v is before MPD publishTime %v", cdn, want)
+	}
+	if cdn.Sub(want) > 2*time.Second {
+		t.Errorf("cached CDN clock %v extrapolated too far past publishTime %v", cdn, want)
+	}
+}

--- a/internal/handlers/epg.go
+++ b/internal/handlers/epg.go
@@ -1,31 +1,42 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/proxy"
 	"github.com/jiotv-go/jiotv_go/v3/internal/constants/urls"
 	internalUtils "github.com/jiotv-go/jiotv_go/v3/internal/utils"
 	"github.com/jiotv-go/jiotv_go/v3/pkg/epg"
-	"github.com/jiotv-go/jiotv_go/v3/pkg/utils"
+	pkgUtils "github.com/jiotv-go/jiotv_go/v3/pkg/utils"
+	"github.com/valyala/fasthttp"
 )
 
 const (
 	EPG_POSTER_URL = urls.EPGPosterURLSlash
+	// The getepg API stamps serverDate with IST (UTC+05:30) day boundaries;
+	// real-day indices are computed in that same timezone.
+	istOffsetMS = 5.5 * 60 * 60 * 1000
+	dayMS       = 24 * 60 * 60 * 1000
 )
+
+// webEPGURLFormat is the upstream getepg URL pattern. It is a variable rather
+// than epg.EPG_URL directly so tests can point it at a local server.
+var webEPGURLFormat = epg.EPG_URL
 
 // EPGHandler handles EPG requests
 func EPGHandler(c *fiber.Ctx) error {
-	epgFilePath := utils.GetPathPrefix() + "epg.xml.gz"
+	epgFilePath := pkgUtils.GetPathPrefix() + "epg.xml.gz"
 	// if epg.xml.gz exists, return it
 	if _, err := os.Stat(epgFilePath); err == nil {
 		return c.SendFile(epgFilePath, true)
 	} else {
 		err_message := "EPG not found. Please restart the server after setting the environment variable JIOTV_EPG to true."
-		utils.Log.Println(err_message) // Changed from fmt.Println
+		pkgUtils.Log.Println(err_message) // Changed from fmt.Println
 		return internalUtils.NotFoundError(c, err_message)
 	}
 }
@@ -35,7 +46,7 @@ func WebEPGHandler(c *fiber.Ctx) error {
 	// Get channel ID from URL
 	channelID := c.Params("channelID")
 
-	if channelID[:2] == "sl" {
+	if strings.HasPrefix(channelID, "sl") {
 		channelID = channelID[2:]
 	}
 
@@ -50,13 +61,84 @@ func WebEPGHandler(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid offset")
 	}
 
-	url := fmt.Sprintf(epg.EPG_URL, offset, channelIntID)
-	if err := proxy.Do(c, url, TV.Client); err != nil {
+	body, contentType, statusCode, err := webEPGWithCorrectedDay(channelIntID, offset)
+	if err != nil {
 		return err
 	}
 
+	c.Status(statusCode)
+	if contentType != "" {
+		c.Set(fiber.HeaderContentType, contentType)
+	} else {
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	}
 	c.Response().Header.Del(fiber.HeaderServer)
-	return nil
+	return c.Send(body)
+}
+
+// webEPGWithCorrectedDay fetches the schedule for the requested day and, if
+// the response's serverDate shows the API's "today" lags real time, re-fetches
+// with the corrected offset so the returned schedule covers the present moment
+// for any client. It falls back to the original response if the corrected
+// fetch fails.
+func webEPGWithCorrectedDay(channelID, offset int) ([]byte, string, int, error) {
+	body, contentType, statusCode, err := fetchWebEPG(channelID, offset)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	if statusCode == fiber.StatusOK {
+		if dayOffset := webEPGDayOffset(body); dayOffset > 0 {
+			if adjusted, adjType, adjStatus, adjErr := fetchWebEPG(channelID, offset+dayOffset); adjErr == nil && adjStatus == fiber.StatusOK {
+				return adjusted, adjType, adjStatus, nil
+			}
+		}
+	}
+	return body, contentType, statusCode, nil
+}
+
+// fetchWebEPG fetches the EPG schedule for a channel from the JioTV API and
+// returns the response body, content type, and status code.
+func fetchWebEPG(channelID, offset int) ([]byte, string, int, error) {
+	url := fmt.Sprintf(webEPGURLFormat, offset, channelID)
+	resp, err := pkgUtils.MakeHTTPRequest(pkgUtils.HTTPRequestConfig{
+		URL:    url,
+		Method: "GET",
+	}, TV.Client)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := make([]byte, len(resp.Body()))
+	copy(body, resp.Body())
+	return body, string(resp.Header.ContentType()), resp.StatusCode(), nil
+}
+
+// webEPGDayOffset returns how many days the EPG API's "today" lags the real
+// date, derived from the serverDate the API stamps on its response. It returns
+// 0 when the offset cannot be determined, meaning nothing to correct.
+func webEPGDayOffset(body []byte) int {
+	var resp struct {
+		EPG []struct {
+			ServerDate string `json:"serverDate"`
+		} `json:"epg"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil || len(resp.EPG) == 0 {
+		return 0
+	}
+	if resp.EPG[0].ServerDate == "" {
+		return 0
+	}
+	serverDayStart, err := time.Parse(time.RFC3339Nano, resp.EPG[0].ServerDate)
+	if err != nil {
+		return 0
+	}
+	epgDay := (serverDayStart.UnixMilli() + istOffsetMS) / dayMS
+	today := (time.Now().UnixMilli() + istOffsetMS) / dayMS
+	if delta := int(today - epgDay); delta > 0 {
+		return delta
+	}
+	return 0
 }
 
 // PosterHandler loads image from JioTV server

--- a/internal/handlers/epg_test.go
+++ b/internal/handlers/epg_test.go
@@ -1,47 +1,262 @@
 package handlers
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/jiotv-go/jiotv_go/v3/pkg/television"
+	"github.com/valyala/fasthttp"
 )
 
-func TestWebEPGHandler(t *testing.T) {
-	type args struct {
-		c *fiber.Ctx
-	}
+// istDateString formats the IST calendar date containing the given instant the
+// way the getepg API stamps serverDate, e.g. "2026-08-13T00:00:00+05:30".
+func istDateString(ms int64) string {
+	ist := time.UnixMilli(ms).Add(5*time.Hour + 30*time.Minute).UTC()
+	return fmt.Sprintf("%04d-%02d-%02dT00:00:00+05:30", ist.Year(), ist.Month(), ist.Day())
+}
+
+// epgJSONBody builds a minimal getepg-style response with one show entry.
+func epgJSONBody(serverDate, showName string) []byte {
+	now := time.Now().UnixMilli()
+	b, _ := json.Marshal(map[string]any{
+		"epg": []map[string]any{
+			{
+				"showname":   showName,
+				"serverDate": serverDate,
+				"startEpoch": now - 600000,
+				"endEpoch":   now + 600000,
+			},
+		},
+	})
+	return b
+}
+
+func TestWebEPGDayOffset(t *testing.T) {
+	now := time.Now().UnixMilli()
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name string
+		body []byte
+		want int
 	}{
-		// No test cases - EPG handler function
+		{
+			name: "server a day behind returns 1",
+			body: epgJSONBody(istDateString(now-24*time.Hour.Milliseconds()), "Yesterday Show"),
+			want: 1,
+		},
+		{
+			name: "server date today returns 0",
+			body: epgJSONBody(istDateString(now), "Today Show"),
+			want: 0,
+		},
+		{
+			name: "server date in the future returns 0",
+			body: epgJSONBody(istDateString(now+24*time.Hour.Milliseconds()), "Tomorrow Show"),
+			want: 0,
+		},
+		{
+			name: "empty epg array returns 0",
+			body: []byte(`{"epg":[]}`),
+			want: 0,
+		},
+		{
+			name: "invalid json returns 0",
+			body: []byte(`not-json`),
+			want: 0,
+		},
+		{
+			name: "missing serverDate returns 0",
+			body: []byte(`{"epg":[{"showname":"No Date"}]}`),
+			want: 0,
+		},
+		{
+			name: "malformed serverDate returns 0",
+			body: []byte(`{"epg":[{"serverDate":"not-a-date"}]}`),
+			want: 0,
+		},
+		{
+			name: "nil body returns 0",
+			body: nil,
+			want: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := WebEPGHandler(tt.args.c); (err != nil) != tt.wantErr {
-				t.Errorf("WebEPGHandler() error = %v, wantErr %v", err, tt.wantErr)
+			if got := webEPGDayOffset(tt.body); got != tt.want {
+				t.Errorf("webEPGDayOffset() = %d, want %d", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestPosterHandler(t *testing.T) {
-	type args struct {
-		c *fiber.Ctx
+// setupWebEPGTest installs the global state WebEPGHandler needs (TV client and
+// the upstream URL format) and returns a cleanup function.
+func setupWebEPGTest(t *testing.T, upstreamURL string) func() {
+	t.Helper()
+	previousTV, previousURL := TV, webEPGURLFormat
+	TV = &television.Television{
+		Client: &fasthttp.Client{},
 	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		// No test cases - EPG handler function
+	webEPGURLFormat = upstreamURL + "/getepg?offset=%d&channel_id=%d"
+	return func() {
+		TV = previousTV
+		webEPGURLFormat = previousURL
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := PosterHandler(tt.args.c); (err != nil) != tt.wantErr {
-				t.Errorf("PosterHandler() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+}
+
+// epgUpstream returns a fake getepg server. offset 0 serves yesterday's
+// schedule, any other offset serves today's schedule, so a corrected request
+// (offset 1) is distinguishable from the original.
+func epgUpstream(t *testing.T) (*httptest.Server, *[]int, *sync.Mutex) {
+	t.Helper()
+	var mu sync.Mutex
+	var offsets []int
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		off, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		mu.Lock()
+		offsets = append(offsets, off)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		now := time.Now().UnixMilli()
+		if off == 0 {
+			_, _ = w.Write(epgJSONBody(istDateString(now-24*time.Hour.Milliseconds()), "Yesterday Show"))
+			return
+		}
+		_, _ = w.Write(epgJSONBody(istDateString(now), "Today Show"))
+	}))
+	t.Cleanup(upstream.Close)
+	return upstream, &offsets, &mu
+}
+
+func TestWebEPGHandlerCorrectsDayOffset(t *testing.T) {
+	upstream, offsets, mu := epgUpstream(t)
+	defer setupWebEPGTest(t, upstream.URL)()
+
+	app := fiber.New()
+	app.Get("/epg/:channelID/:offset", WebEPGHandler)
+
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/epg/336/0", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (body: %s)", response.StatusCode, http.StatusOK, body)
+	}
+	if !strings.Contains(string(body), "Today Show") {
+		t.Errorf("body serves yesterday's schedule, want corrected (today's) schedule: %s", body)
+	}
+	if strings.Contains(string(body), "Yesterday Show") {
+		t.Errorf("body contains yesterday's schedule: %s", body)
+	}
+	if ct := response.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	mu.Lock()
+	got := append([]int(nil), *offsets...)
+	mu.Unlock()
+	if len(got) != 2 || got[0] != 0 || got[1] != 1 {
+		t.Errorf("upstream offsets = %v, want [0 1] (original request plus one corrected)", got)
+	}
+}
+
+func TestWebEPGHandlerKeepsCorrectOffset(t *testing.T) {
+	// When the API already serves today's schedule, no corrected re-fetch
+	// should happen.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(epgJSONBody(istDateString(time.Now().UnixMilli()), "Today Show"))
+	}))
+	defer upstream.Close()
+	defer setupWebEPGTest(t, upstream.URL)()
+
+	app := fiber.New()
+	app.Get("/epg/:channelID/:offset", WebEPGHandler)
+
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/epg/336/1", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (body: %s)", response.StatusCode, http.StatusOK, body)
+	}
+	if !strings.Contains(string(body), "Today Show") {
+		t.Errorf("body = %s, want today's schedule unchanged", body)
+	}
+}
+
+func TestWebEPGHandlerFallsBackWhenCorrectionFails(t *testing.T) {
+	// If the corrected (offset 1) fetch fails, the handler must serve the
+	// original response instead of erroring.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		off, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		w.Header().Set("Content-Type", "application/json")
+		if off == 0 {
+			_, _ = w.Write(epgJSONBody(istDateString(time.Now().UnixMilli()-24*time.Hour.Milliseconds()), "Yesterday Show"))
+			return
+		}
+		http.Error(w, "upstream failure", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+	defer setupWebEPGTest(t, upstream.URL)()
+
+	app := fiber.New()
+	app.Get("/epg/:channelID/:offset", WebEPGHandler)
+
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/epg/336/0", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (original response served on correction failure)", response.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(body), "Yesterday Show") {
+		t.Errorf("body = %s, want the original (uncorrected) response", body)
+	}
+}
+
+func TestWebEPGHandlerBadRequest(t *testing.T) {
+	defer setupWebEPGTest(t, "http://127.0.0.1:1")()
+
+	app := fiber.New()
+	app.Get("/epg/:channelID/:offset", WebEPGHandler)
+
+	for _, path := range []string{"/epg/abc/0", "/epg/336/abc"} {
+		response, err := app.Test(httptest.NewRequest(http.MethodGet, path, nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want %d", path, response.StatusCode, http.StatusBadRequest)
+		}
 	}
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -1273,8 +1274,23 @@ func ImageHandler(c *fiber.Ctx) error {
 	return internalUtils.ProxyRequest(c, url, TV.Client, REQUEST_USER_AGENT)
 }
 
+// DASHTimeHandler serves a UTC timestamp for DASH clock sync (UTCTiming).
+// The proxied MPD's segment timeline is stamped with the upstream CDN's
+// clock, so this returns the CDN's extrapolated clock when one has been
+// observed (see recordCdnPublishTime), falling back to the machine clock
+// before the first MPD fetch. Serving the machine clock directly stalls live
+// playback whenever it differs from the CDN clock: players compute the live
+// edge minutes away from the actual segments.
 func DASHTimeHandler(c *fiber.Ctx) error {
-	return c.SendString(time.Now().UTC().Format("2006-01-02T15:04:05.000Z"))
+	now := time.Now().UTC()
+	if cdn, ok := cdnNow(); ok {
+		now = cdn.UTC()
+	}
+	// The Shaka player reads the Date header when clockSyncUri uses the
+	// http-head UTCTiming scheme, so make sure it is present even if the
+	// HTTP framework does not add it automatically.
+	c.Set("Date", now.Format(http.TimeFormat))
+	return c.SendString(now.Format("2006-01-02T15:04:05.000Z"))
 }
 
 // GenerateM3UPlaylist generates an M3U playlist string from a list of channels

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/jiotv-go/jiotv_go/v3/internal/config"
@@ -493,6 +495,86 @@ func TestDASHTimeHandler(t *testing.T) {
 				t.Errorf("DASHTimeHandler() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestDASHTimeHandlerServesCDNClock verifies that /dashtime reports the
+// upstream CDN clock (recorded from the MPD publishTime) rather than the
+// machine clock, so players sync to the clock the segment timeline uses.
+func TestDASHTimeHandlerServesCDNClock(t *testing.T) {
+	origPT, origFA := cdnPublishTime, cdnPublishFetchedAt
+	t.Cleanup(func() {
+		cdnClockMu.Lock()
+		defer cdnClockMu.Unlock()
+		cdnPublishTime, cdnPublishFetchedAt = origPT, origFA
+	})
+	// Guarantee the fallback path regardless of test ordering.
+	cdnClockMu.Lock()
+	cdnPublishTime, cdnPublishFetchedAt = time.Time{}, time.Time{}
+	cdnClockMu.Unlock()
+
+	// No observation yet -> falls back to the machine clock (current year).
+	c := createMockFiberContext("GET", "/dashtime")
+	if err := DASHTimeHandler(c); err != nil {
+		t.Fatalf("DASHTimeHandler() error = %v", err)
+	}
+	if body := string(c.Response().Body()); !strings.Contains(body, fmt.Sprintf("%d-", time.Now().UTC().Year())) {
+		t.Errorf("fallback DASHTimeHandler body = %q, want current-year prefix", body)
+	}
+
+	// With an observed CDN clock, the served time must follow it.
+	recordCdnPublishTime(time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC))
+	c2 := createMockFiberContext("GET", "/dashtime")
+	if err := DASHTimeHandler(c2); err != nil {
+		t.Fatalf("DASHTimeHandler() error = %v", err)
+	}
+	if body := string(c2.Response().Body()); !strings.Contains(body, "2030-01-01T00:00:") {
+		t.Errorf("DASHTimeHandler body = %q, want extrapolated CDN clock 2030-01-01T00:00:xx", body)
+	}
+}
+
+// TestExtractPublishTime verifies publishTime is parsed from live MPD bodies
+// and absent when the attribute is missing.
+func TestExtractPublishTime(t *testing.T) {
+	body := []byte(`<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" availabilityStartTime="1970-01-01T00:00:00Z" publishTime="2026-08-12T20:15:49.537686Z" minimumUpdatePeriod="PT2S">`)
+	pt, ok := extractPublishTime(body)
+	if !ok {
+		t.Fatal("expected publishTime to be extracted")
+	}
+	want := time.Date(2026, 8, 12, 20, 15, 49, 537686000, time.UTC)
+	if !pt.Equal(want) {
+		t.Errorf("extractPublishTime() = %v, want %v", pt, want)
+	}
+	if _, ok := extractPublishTime([]byte(`<MPD></MPD>`)); ok {
+		t.Error("expected no publishTime match for MPD without the attribute")
+	}
+}
+
+// TestCDNClockExtrapolation verifies cdnNow returns the recorded publishTime
+// plus elapsed time and reports false before any observation exists.
+func TestCDNClockExtrapolation(t *testing.T) {
+	origPT, origFA := cdnPublishTime, cdnPublishFetchedAt
+	t.Cleanup(func() {
+		cdnClockMu.Lock()
+		defer cdnClockMu.Unlock()
+		cdnPublishTime, cdnPublishFetchedAt = origPT, origFA
+	})
+
+	if _, ok := cdnNow(); ok {
+		t.Error("cdnNow should report false before any publishTime is recorded")
+	}
+
+	fixed := time.Date(2026, 8, 12, 20, 15, 49, 0, time.UTC)
+	recordCdnPublishTime(fixed)
+	got, ok := cdnNow()
+	if !ok {
+		t.Fatal("cdnNow should report true after recording")
+	}
+	if got.Before(fixed) {
+		t.Errorf("cdnNow %v is before recorded publishTime %v", got, fixed)
+	}
+	if got.Sub(fixed) > 2*time.Second {
+		t.Errorf("cdnNow %v extrapolated too far from %v", got, fixed)
 	}
 }
 

--- a/pkg/secureurl/secureurl.go
+++ b/pkg/secureurl/secureurl.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -49,6 +50,38 @@ func EncryptURL(inputURL string) (string, error) {
 
 	encryptedURL := base64.URLEncoding.EncodeToString(ciphertext)
 	return encryptedURL, nil
+}
+
+// EncryptURLDeterministic encrypts inputURL like EncryptURL but without the
+// random IV: the same input always produces the same ciphertext. The
+// /render.dash host/path/hdnea components use this so segment URLs stay
+// byte-identical across live manifest refreshes. (Shaka treats a changed
+// segment URL as a new segment and re-downloads it, which multiplied the
+// requests needed before playback could start.) DecryptURL reads both forms
+// unchanged because the nonce is stored in the first block-size bytes.
+func EncryptURLDeterministic(inputURL string) (string, error) {
+	if disableUrlEncryption {
+		return url.QueryEscape(inputURL), nil
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	// Derive a stable nonce from the key and input instead of reading a
+	// random IV: identical inputs produce identical ciphertexts while
+	// different inputs still use different key streams.
+	sum := sha256.Sum256(append(append([]byte{}, key...), []byte(inputURL)...))
+	nonce := sum[:aes.BlockSize]
+
+	ciphertext := make([]byte, aes.BlockSize+len(inputURL))
+	copy(ciphertext[:aes.BlockSize], nonce)
+
+	stream := cipher.NewCTR(block, nonce)
+	stream.XORKeyStream(ciphertext[aes.BlockSize:], []byte(inputURL))
+
+	return base64.URLEncoding.EncodeToString(ciphertext), nil
 }
 
 func DecryptURL(encryptedURL string) (string, error) {

--- a/pkg/secureurl/secureurl_test.go
+++ b/pkg/secureurl/secureurl_test.go
@@ -79,6 +79,57 @@ func TestEncryptURL(t *testing.T) {
 	}
 }
 
+func TestEncryptURLDeterministic(t *testing.T) {
+	// Initialize the package first so the key is stable for this test run.
+	Init()
+
+	inputs := []string{
+		"cdn.jio.com",
+		"/tv/stream/",
+		"__hdnea__=some-cdn-token-value",
+		"",
+	}
+
+	for _, input := range inputs {
+		t.Run("Deterministic round-trip for: "+input, func(t *testing.T) {
+			first, err := EncryptURLDeterministic(input)
+			if err != nil {
+				t.Fatalf("EncryptURLDeterministic() error = %v", err)
+			}
+
+			// The same input must always produce the same ciphertext. The
+			// /render.dash host/path/hdnea components rely on this so segment
+			// URLs stay stable across live manifest refreshes.
+			second, err := EncryptURLDeterministic(input)
+			if err != nil {
+				t.Fatalf("EncryptURLDeterministic() error = %v", err)
+			}
+			if first != second {
+				t.Errorf("EncryptURLDeterministic(%q) is not stable: %q != %q", input, first, second)
+			}
+
+			// DecryptURL must be able to read the deterministic form.
+			decrypted, err := DecryptURL(first)
+			if err != nil {
+				t.Fatalf("DecryptURL() error = %v", err)
+			}
+			if decrypted != input {
+				t.Errorf("DecryptURL() = %q, want %q", decrypted, input)
+			}
+
+			// A random-IV encryption of the same input should differ from the
+			// deterministic form (they are different code paths on purpose).
+			randomized, err := EncryptURL(input)
+			if err != nil {
+				t.Fatalf("EncryptURL() error = %v", err)
+			}
+			if first == randomized {
+				t.Errorf("EncryptURLDeterministic(%q) unexpectedly equals the randomized EncryptURL form", input)
+			}
+		})
+	}
+}
+
 func TestDecryptURL(t *testing.T) {
 	// Initialize the package first
 	Init()

--- a/web/views/player_drm.html
+++ b/web/views/player_drm.html
@@ -203,14 +203,24 @@
         });
 
         const licenseUrl = "{{ .license_url }}";
+        const isDRM = !!licenseUrl;
 
         if (licenseUrl) {
-          const support = await shaka.Player.probeSupport();
-          const drmSupport = support.drm || {};
-          const hasWidevineSupport = Object.keys(drmSupport).some((key) =>
-            key.includes("com.widevine.alpha")
-          );
-          if (!hasWidevineSupport) {
+          // Fast Widevine-only capability check. shaka.Player.probeSupport()
+          // probes EVERY key system - including PlayReady on Windows, whose
+          // CDM is extremely slow to respond - and can stall the page for
+          // minutes before playback even starts. JioTV streams are Widevine
+          // only, so a single requestMediaKeySystemAccess call is enough.
+          try {
+            await navigator.requestMediaKeySystemAccess("com.widevine.alpha", [
+              {
+                initDataTypes: ["cenc"],
+                videoCapabilities: [
+                  { contentType: 'video/mp4; codecs="avc1.42E01E"' },
+                ],
+              },
+            ]);
+          } catch (e) {
             fallbackToHLS("Widevine not supported");
             return;
           }
@@ -226,21 +236,39 @@
                 "com.widevine.alpha": {
                   videoRobustness: "SW_SECURE_CRYPTO",
                   audioRobustness: "SW_SECURE_CRYPTO",
-                }
-              }
+                },
+              },
             },
           });
         }
 
         player.configure({
-          streaming: {
-            retryParameters: {
-              maxAttempts: 5,  // Increase retry attempts for segment failures
-              backoffFactor: 2,
-              timeout: 30000,  // 30 second timeout
+          manifest: {
+            dash: {
+              // JioTV live MPDs have no UTCTiming element; point Shaka at the
+              // server clock (/dashtime returns an ISO timestamp and a Date
+              // header) so the live edge is computed from server time instead
+              // of the client clock. A skewed clock makes Shaka fetch far more
+              // segments than needed while it hunts for the live edge.
+              clockSyncUri: "/dashtime",
             },
-            bufferBehind: 5, // seconds of buffer kept behind the playhead
-            bufferingGoal: 30, // seconds of buffer kept ahead of the playhead
+          },
+          streaming: {
+            // Cap retries: each failed segment would otherwise multiply into
+            // several requests with long backoff, which turns a few expired
+            // HDNEA tokens into hundreds of slow segment requests.
+            retryParameters: {
+              maxAttempts: 2,
+              backoffFactor: 2,
+              timeout: 30000,
+            },
+            // JioTV premium streams use very short segments, so a large
+            // buffering goal multiplies the segment requests needed before
+            // playback can start. Keep the DRM buffer lean and the HLS
+            // fallback at the original, more generous values.
+            bufferBehind: isDRM ? 2 : 5,
+            bufferingGoal: isDRM ? 6 : 30,
+            rebufferingGoal: 2,
           },
         });
 


### PR DESCRIPTION
## What this PR does

Fixes two problems in the web player.

### 1. DRM (premium) channels took minutes to start playing

Star channels like Star Pravah and Star Movies often showed a black screen for 1-3+ minutes before video appeared, while Sony channels started instantly.

**Why:** the stream's segment timeline is stamped with the CDN's clock, which was running minutes ahead of the computer's clock. The player used the computer's clock to work out where "live" is, so it parked the playhead minutes behind the actual live picture - downloading segments it could never display until it eventually caught up.

**Fixes:**
- `/dashtime` now returns the **CDN's clock** (taken from the live playlist) instead of the machine's clock, and live playlists point the player at it. The player now knows exactly where live is.
- Segment URLs no longer change between playlist refreshes, so the player stops re-downloading the same segments.
- The DRM capability check no longer probes every DRM system (the PlayReady probe is extremely slow on Windows); it only checks Widevine.
- Smaller DRM buffer and fewer retries so short premium segments fill up fast; expired CDN tokens are retried immediately instead of forcing a slow token refresh.

**Result:** channels that took ~2.4 minutes now start in ~1-3 seconds (verified in Chrome with strict rendering checks: playhead inside the buffered range, readyState 4).

### 2. The "Now Playing" guide was empty

JioTV's guide server was returning **yesterday's** schedule, so no show matched "now" and the panel stayed blank. The server now detects this one-day lag from the guide data itself and fetches the correct day before replying - so the web UI (and any other client) always gets the day that covers the present moment.

## Testing

- New Go tests: CDN clock sync, stable segment URLs, per-segment 403 retry, EPG day-offset correction - all offline (`go test ./internal/handlers/` passes).
- Frontend Jest suite: 132/132 tests pass.
- Manually verified: Star Channels starts in ~1.6s, Now Playing shows the current show.
