### PR TITLE
feat: filter subscription channels from M3U playlist

### DIFF
--- a/docs/usage/iptv.md
+++ b/docs/usage/iptv.md
@@ -63,16 +63,26 @@ JioTV Go offers a convenient M3U playlist endpoint to enhance your IPTV experien
 
    This will skip all channels from provided list of genres.
 
+7. If you would like to hide channels that require a separate subscription, append the `sub=hide` query parameter:
+
+   ```
+   http://localhost:5001/playlist.m3u?sub=hide
+   ```
+
+   This is the playlist equivalent of the "Hide channels requiring a separate subscription" checkbox on the home page. Use `sub=only` for the inverse, a playlist containing nothing but the channels that need a subscription.
+
+   Any other value, including leaving `sub` out entirely, returns the full playlist.
+
 For both specific quality and split category, append the `q=` and `c=` query parameters:
 
 ```
 http://localhost:5001/playlist.m3u?q=high&c=split
 ```
 
-You can also combine the language grouping and language filtering:
+You can also combine the language grouping, language filtering and subscription filtering:
 
 ```
-http://localhost:5001/playlist.m3u?c=language&l=Hindi,Kannada,Marathi
+http://localhost:5001/playlist.m3u?c=language&l=Hindi,Kannada,Marathi&sub=hide
 ```
 
 

--- a/docs/usage/paths.md
+++ b/docs/usage/paths.md
@@ -66,11 +66,13 @@ You can also append `&c=split` to the path to have categories based on both lang
 You can also append `&sg=<genre_list>` to the path in order to skip specific genres. Here replace `<genre_list>` with comma(,) seperated list of genres.
 Valid genres: `Entertainment`, `Movies`, `Kids`, `Sports`, `Lifestyle`, `Infotainment`, `News`, `Music`, `Devotional`, `Business`, `Educational`, `Shopping`, `JioDarshan`
 
+You can also append `&sub=hide` to the path to leave out channels that require a separate subscription, or `&sub=only` to get a playlist of just those channels. Any other value, including omitting `sub`, returns every channel. This is the playlist equivalent of the "Hide channels requiring a separate subscription" checkbox on the home page.
+
 ### M3U Playlist
 
 - **Path**: `/channels?type=m3u`
 
-The actual path for the M3U playlist. You can append `&q=<level>` to the path as [above](#m3u-playlist-alias). You can also append `&c=split` to the path as [above](#m3u-playlist-alias).
+The actual path for the M3U playlist. You can append `&q=<level>` to the path as [above](#m3u-playlist-alias). You can also append `&c=split` or `&sub=hide` to the path as [above](#m3u-playlist-alias).
 
 ### M3U8 URL
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1023,6 +1023,7 @@ func ChannelsHandler(c *fiber.Ctx) error {
 	splitCategory := strings.TrimSpace(c.Query("c"))
 	languages := strings.TrimSpace(c.Query("l"))
 	skipGenres := strings.TrimSpace(c.Query("sg"))
+	subFilter := strings.TrimSpace(c.Query("sub"))
 	apiResponse, err := television.Channels()
 	if err != nil {
 		return ErrorMessageHandler(c, err)
@@ -1033,7 +1034,7 @@ func ChannelsHandler(c *fiber.Ctx) error {
 	// Check if the query parameter "type" is set to "m3u"
 	if c.Query("type") == "m3u" {
 		// Create an M3U playlist
-		m3uContent := GenerateM3UPlaylist(apiResponse.Result, hostURL, quality, splitCategory, languages, skipGenres)
+		m3uContent := GenerateM3UPlaylist(apiResponse.Result, hostURL, quality, splitCategory, languages, skipGenres, subFilter)
 
 		// Set the Content-Disposition header for file download
 		c.Set("Content-Disposition", "attachment; filename=jiotv_playlist.m3u")
@@ -1264,7 +1265,8 @@ func PlaylistHandler(c *fiber.Ctx) error {
 	splitCategory := c.Query("c")
 	languages := c.Query("l")
 	skipGenres := c.Query("sg")
-	return c.Redirect("/channels?type=m3u&q="+quality+"&c="+splitCategory+"&l="+languages+"&sg="+skipGenres, fiber.StatusMovedPermanently)
+	subFilter := c.Query("sub")
+	return c.Redirect("/channels?type=m3u&q="+quality+"&c="+splitCategory+"&l="+languages+"&sg="+skipGenres+"&sub="+subFilter, fiber.StatusMovedPermanently)
 }
 
 // ImageHandler loads image from JioTV server
@@ -1278,7 +1280,7 @@ func DASHTimeHandler(c *fiber.Ctx) error {
 }
 
 // GenerateM3UPlaylist generates an M3U playlist string from a list of channels
-func GenerateM3UPlaylist(channels []television.Channel, hostURL, quality, splitCategory, languages, skipGenres string) string {
+func GenerateM3UPlaylist(channels []television.Channel, hostURL, quality, splitCategory, languages, skipGenres, subFilter string) string {
 	var m3uContent strings.Builder
 	m3uContent.WriteString("#EXTM3U x-tvg-url=\"")
 	m3uContent.WriteString(hostURL)
@@ -1292,6 +1294,17 @@ func GenerateM3UPlaylist(channels []television.Channel, hostURL, quality, splitC
 
 		if skipGenres != "" && utils.ContainsString(television.CategoryMap[channel.Category], strings.Split(skipGenres, ",")) {
 			continue
+		}
+
+		switch subFilter {
+		case "hide":
+			if channel.RequiresSubscription {
+				continue
+			}
+		case "only":
+			if !channel.RequiresSubscription {
+				continue
+			}
 		}
 
 		var channelURL string

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -745,7 +745,7 @@ func TestChannelsHandlerM3UDRM(t *testing.T) {
 			}
 
 			// Generate playlist
-			playlist := GenerateM3UPlaylist(mockChannels, hostURL, tc.quality, "", "", "")
+			playlist := GenerateM3UPlaylist(mockChannels, hostURL, tc.quality, "", "", "", "")
 
 			// Verify the output contains the expected elements
 			if !strings.Contains(playlist, tc.expectedURL) {
@@ -758,6 +758,92 @@ func TestChannelsHandlerM3UDRM(t *testing.T) {
 			// Verify non-DRM shouldn't have KODIPROP tags
 			if tc.expectedProps == "" && strings.Contains(playlist, "#KODIPROP") {
 				t.Errorf("Expected playlist to NOT contain KODIPROP tags, but found them: \n%s", playlist)
+			}
+		})
+	}
+}
+
+func TestGenerateM3UPlaylistSubscriptionFilter(t *testing.T) {
+	const (
+		freeChannelID = "100"
+		paidChannelID = "200"
+	)
+
+	// One channel of each kind, identical in every other respect
+	mockChannels := []television.Channel{
+		{
+			ID:       freeChannelID,
+			Name:     "Free Channel",
+			LogoURL:  "free.png",
+			Category: 1, // Entertainment
+			Language: 1, // Hindi
+		},
+		{
+			ID:                   paidChannelID,
+			Name:                 "Paid Channel",
+			LogoURL:              "paid.png",
+			Category:             1, // Entertainment
+			Language:             1, // Hindi
+			RequiresSubscription: true,
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		subFilter  string
+		expectFree bool
+		expectPaid bool
+	}{
+		{
+			name:       "AbsentKeepsEveryChannel",
+			subFilter:  "",
+			expectFree: true,
+			expectPaid: true,
+		},
+		{
+			name:       "HideDropsSubscriptionChannels",
+			subFilter:  "hide",
+			expectFree: true,
+			expectPaid: false,
+		},
+		{
+			name:       "OnlyKeepsSubscriptionChannels",
+			subFilter:  "only",
+			expectFree: false,
+			expectPaid: true,
+		},
+		{
+			name:       "UnknownValueFallsBackToDefault",
+			subFilter:  "banana",
+			expectFree: true,
+			expectPaid: true,
+		},
+		{
+			// Booleans are deliberately not accepted as aliases, because
+			// "true" is ambiguous between "include them" and "only them".
+			name:       "BooleanIsNotAnAlias",
+			subFilter:  "true",
+			expectFree: true,
+			expectPaid: true,
+		},
+	}
+
+	hostURL := "http://localhost:5001"
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			playlist := GenerateM3UPlaylist(mockChannels, hostURL, "", "", "", "", tc.subFilter)
+
+			// Assert on tvg-id rather than counting lines, so that dropping
+			// the wrong channel fails instead of passing on the right count
+			freeTag := `tvg-id="` + freeChannelID + `"`
+			paidTag := `tvg-id="` + paidChannelID + `"`
+
+			if got := strings.Contains(playlist, freeTag); got != tc.expectFree {
+				t.Errorf("sub=%q: free channel present = %v, want %v, got: \n%s", tc.subFilter, got, tc.expectFree, playlist)
+			}
+			if got := strings.Contains(playlist, paidTag); got != tc.expectPaid {
+				t.Errorf("sub=%q: subscription channel present = %v, want %v, got: \n%s", tc.subFilter, got, tc.expectPaid, playlist)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`Channel.RequiresSubscription` is already computed and the web UI already uses it, but the M3U generator never reads it. IPTV clients end up with a playlist where a chunk of the entries can never play, failing at the playback API with "No eligible plans found".

## Changes

Adds an optional `sub` parameter to the M3U playlist:

- `sub=hide` leaves out channels that need a separate subscription
- `sub=only` returns just those channels
- anything else, including leaving it out, returns the full playlist as before

It is a mode word rather than a boolean because `sub=true` reads both ways, and a boolean cannot express the `only` case. This follows the existing `c` and `pm` parameters.

The filtering is a third skip guard in `GenerateM3UPlaylist`, next to the two already there for `l` and `sg`. `ChannelsHandler` reads the parameter and `PlaylistHandler` forwards it through the redirect, so `/playlist.m3u?sub=hide` and `/channels?type=m3u&sub=hide` return the same thing.

Docs updated in `docs/usage/iptv.md` and `docs/usage/paths.md`.
